### PR TITLE
Add results history

### DIFF
--- a/src/Client/extension.ts
+++ b/src/Client/extension.ts
@@ -14,6 +14,7 @@ import * as clientStorage from './features/clientStorage'
 import * as dotnet from './features/dotnet'
 import * as resultsCache from './features/resultsCache'
 import * as scratchPad from './features/scratchPad'
+import * as history from './features/history'
 import { SCRATCH_PAD_SCHEME } from './features/scratchPad'
 import { registerEntityDefinitionProvider, ENTITY_DEFINITION_SCHEME } from './features/entityDefinitionProvider'
 import
@@ -142,6 +143,9 @@ export async function activate(context: ExtensionContext)
 
     // activate scratch pad documents
     await scratchPad.activate(context);
+
+    // activate query history
+    await history.activate(context);
 
     // activate chart file editor (.kchart)
     resultsViewer.activate(context, client);

--- a/src/Client/features/history.ts
+++ b/src/Client/features/history.ts
@@ -1,0 +1,286 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as server from './server';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Maximum number of history entries to keep. */
+const MAX_HISTORY_ENTRIES = 200;
+
+/** Filename for the lightweight index that powers the tree view. */
+const INDEX_FILE = 'history-index.json';
+
+// =============================================================================
+// Module-level State
+// =============================================================================
+
+let historyDir: string;
+let indexPath: string;
+let treeProvider: HistoryTreeProvider;
+let treeView: vscode.TreeView<HistoryItem>;
+
+// =============================================================================
+// Index Types
+// =============================================================================
+
+/** Lightweight metadata for a history entry (stored in the index file). */
+export interface HistoryEntryMeta {
+    /** Filename of the .kqr file in the history directory. */
+    fileName: string;
+    /** ISO 8601 timestamp of when the query was executed. */
+    timestamp: string;
+    /** First ~80 characters of the query text for display. */
+    queryPreview: string;
+    /** Cluster the query was run against. */
+    cluster?: string;
+    /** Database the query was run against. */
+    database?: string;
+    /** Number of result rows. */
+    rowCount?: number;
+}
+
+// =============================================================================
+// Activation
+// =============================================================================
+
+/**
+ * Activates the history feature: creates the storage directory, registers
+ * the tree view and commands.
+ */
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    historyDir = path.join(context.globalStorageUri.fsPath, 'history');
+    await fs.promises.mkdir(historyDir, { recursive: true });
+    indexPath = path.join(historyDir, INDEX_FILE);
+
+    treeProvider = new HistoryTreeProvider();
+    treeView = vscode.window.createTreeView('kusto.history', {
+        treeDataProvider: treeProvider,
+    });
+    context.subscriptions.push(treeView);
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('kusto.openHistoryItem', (item: HistoryItem) => openHistoryItem(item)),
+        vscode.commands.registerCommand('kusto.deleteHistoryItem', (item: HistoryItem) => deleteHistoryItem(item)),
+        vscode.commands.registerCommand('kusto.clearHistory', () => clearHistory()),
+    );
+}
+
+// =============================================================================
+// Index I/O
+// =============================================================================
+
+function readIndex(): HistoryEntryMeta[] {
+    try {
+        if (fs.existsSync(indexPath)) {
+            return JSON.parse(fs.readFileSync(indexPath, 'utf-8')) as HistoryEntryMeta[];
+        }
+    } catch { /* corrupt index — start fresh */ }
+    return [];
+}
+
+function writeIndex(entries: HistoryEntryMeta[]): void {
+    fs.writeFileSync(indexPath, JSON.stringify(entries, null, 2), 'utf-8');
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Adds a query result to the history. Writes a .kqr file and prepends
+ * the entry to the index. Returns the URI of the new history file.
+ */
+export async function addHistoryEntry(resultData: server.ResultData): Promise<vscode.Uri> {
+    const now = new Date();
+    const timestamp = now.toISOString();
+    const datePart = timestamp.replace(/[-:]/g, '').replace('T', '_').replace(/\.\d+Z$/, '');
+
+    // Build a short label from the query text
+    const querySnippet = (resultData.query ?? 'query')
+        .replace(/\s+/g, ' ').trim().slice(0, 60);
+    // Sanitize for use as a filename
+    const safeName = querySnippet.replace(/[<>:"/\\|?*\x00-\x1f]/g, '_').slice(0, 40);
+    const fileName = `${datePart}_${safeName}.kqr`;
+
+    const filePath = path.join(historyDir, fileName);
+    const content = JSON.stringify(resultData, null, 2);
+    await fs.promises.writeFile(filePath, content, 'utf-8');
+
+    const rowCount = resultData.tables.reduce((sum, t) => sum + (t.rows?.length ?? 0), 0);
+
+    const meta: HistoryEntryMeta = {
+        fileName,
+        timestamp,
+        queryPreview: querySnippet,
+        ...(resultData.cluster !== undefined && { cluster: resultData.cluster }),
+        ...(resultData.database !== undefined && { database: resultData.database }),
+        rowCount,
+    };
+
+    // Prepend to index and enforce max size
+    const index = readIndex();
+    index.unshift(meta);
+    if (index.length > MAX_HISTORY_ENTRIES) {
+        // Remove oldest entries and delete their files
+        const removed = index.splice(MAX_HISTORY_ENTRIES);
+        for (const entry of removed) {
+            const p = path.join(historyDir, entry.fileName);
+            try { await fs.promises.unlink(p); } catch { /* ignore */ }
+        }
+    }
+    writeIndex(index);
+    treeProvider.refresh();
+
+    // Select the newly added item in the tree view
+    const newItem = new HistoryItem(meta);
+    treeView.reveal(newItem, { select: true, focus: false });
+
+    return vscode.Uri.file(filePath);
+}
+
+/**
+ * Reads the ResultData from a history .kqr file.
+ */
+export function readHistoryFile(uri: vscode.Uri): server.ResultData | undefined {
+    try {
+        const content = fs.readFileSync(uri.fsPath, 'utf-8');
+        return JSON.parse(content) as server.ResultData;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Writes updated ResultData back to a history .kqr file.
+ */
+export function writeHistoryFile(uri: vscode.Uri, data: server.ResultData): void {
+    const content = JSON.stringify(data, null, 2);
+    fs.writeFileSync(uri.fsPath, content, 'utf-8');
+}
+
+/**
+ * Returns the URI for a history entry's backing file.
+ */
+export function getHistoryFileUri(fileName: string): vscode.Uri {
+    return vscode.Uri.file(path.join(historyDir, fileName));
+}
+
+// =============================================================================
+// Command Handlers
+// =============================================================================
+
+/** Opens a history item in the singleton results view. */
+async function openHistoryItem(item: HistoryItem): Promise<void> {
+    const uri = getHistoryFileUri(item.meta.fileName);
+    const resultData = readHistoryFile(uri);
+    if (!resultData) {
+        vscode.window.showErrorMessage('Failed to read history entry.');
+        return;
+    }
+
+    // Import dynamically to avoid circular dependency at module level
+    const { displayResultsInPanel, displayResultsInSingletonView, setSingletonBackingUri, getLanguageClient } = await import('./resultsViewer');
+    const client = getLanguageClient();
+    if (!client) { return; }
+
+    setSingletonBackingUri(uri);
+    await displayResultsInPanel(client, resultData, 'detail');
+    await displayResultsInSingletonView(client, resultData, 'chart', true);
+}
+
+/** Deletes a history item after confirmation. */
+async function deleteHistoryItem(item: HistoryItem): Promise<void> {
+    const filePath = path.join(historyDir, item.meta.fileName);
+    try { await fs.promises.unlink(filePath); } catch { /* ignore */ }
+
+    const index = readIndex();
+    const filtered = index.filter(e => e.fileName !== item.meta.fileName);
+    writeIndex(filtered);
+    treeProvider.refresh();
+}
+
+/** Clears all history after confirmation. */
+async function clearHistory(): Promise<void> {
+    const confirm = await vscode.window.showWarningMessage(
+        'Delete all query history?',
+        { modal: true },
+        'Delete All'
+    );
+    if (confirm !== 'Delete All') { return; }
+
+    const index = readIndex();
+    for (const entry of index) {
+        const filePath = path.join(historyDir, entry.fileName);
+        try { await fs.promises.unlink(filePath); } catch { /* ignore */ }
+    }
+    writeIndex([]);
+    treeProvider.refresh();
+}
+
+// =============================================================================
+// Tree Data Provider
+// =============================================================================
+
+class HistoryTreeProvider implements vscode.TreeDataProvider<HistoryItem> {
+    private _onDidChange = new vscode.EventEmitter<void>();
+    readonly onDidChangeTreeData = this._onDidChange.event;
+
+    refresh(): void {
+        this._onDidChange.fire();
+    }
+
+    getTreeItem(element: HistoryItem): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(): HistoryItem[] {
+        return readIndex().map(meta => new HistoryItem(meta));
+    }
+
+    getParent(): undefined {
+        return undefined;
+    }
+}
+
+// =============================================================================
+// Tree Items
+// =============================================================================
+
+class HistoryItem extends vscode.TreeItem {
+    constructor(public readonly meta: HistoryEntryMeta) {
+        super(meta.queryPreview, vscode.TreeItemCollapsibleState.None);
+        this.id = meta.fileName;
+
+        // Format timestamp for description
+        const date = new Date(meta.timestamp);
+        const timeStr = date.toLocaleString(undefined, {
+            month: 'short', day: 'numeric',
+            hour: '2-digit', minute: '2-digit',
+        });
+        const parts: string[] = [timeStr];
+        if (meta.rowCount !== undefined) {
+            parts.push(`${meta.rowCount} rows`);
+        }
+        this.description = parts.join(' · ');
+
+        this.tooltip = [
+            meta.queryPreview,
+            `${meta.cluster ?? ''}${meta.database ? '/' + meta.database : ''}`,
+            timeStr,
+        ].filter(Boolean).join('\n');
+
+        this.command = {
+            command: 'kusto.openHistoryItem',
+            title: 'Open',
+            arguments: [this],
+        };
+        this.contextValue = 'historyItem';
+        this.iconPath = new vscode.ThemeIcon('history');
+    }
+}

--- a/src/Client/features/queryDocuments.ts
+++ b/src/Client/features/queryDocuments.ts
@@ -5,8 +5,9 @@ import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { setDocumentConnection, ensureServer, getDocumentConnection } from './connections';
 import * as server from './server';
-import { displayResultsInPanel, displayErrorInPanel, displayResultsInSingletonView, ResultViewMode } from './resultsViewer';
+import { displayResultsInPanel, displayErrorInPanel, displayResultsInSingletonView, setSingletonBackingUri, ResultViewMode } from './resultsViewer';
 import * as resultsCache from './resultsCache';
+import * as history from './history';
 import { getClipboardContext, clearClipboardContext, copyToClipboard } from './clipboard';
 import { ENTITY_DEFINITION_SCHEME } from './entityDefinitionProvider';
 
@@ -151,6 +152,10 @@ async function runQuery(client: LanguageClient, queryRange?: server.SelectionRan
         {
             // Cache the result data on the client side
             await resultsCache.addToCache(uri, queryText, runResult.data);
+
+            // Add to history and use the history file as backing for the singleton view
+            const historyUri = await history.addHistoryEntry(runResult.data);
+            setSingletonBackingUri(historyUri);
 
             // Display result tables and chart from ResultData
             await displayResultsInPanel(client, runResult.data, 'data');

--- a/src/Client/features/resultsViewer.ts
+++ b/src/Client/features/resultsViewer.ts
@@ -47,6 +47,9 @@ const resultViewerViewType = 'kusto.resultViewer';
 /** The language client, set during activation. */
 let languageClient: LanguageClient;
 
+/** Function to wait for the results panel to be resolved. Set during activation. */
+let waitForPanelReady: (() => Promise<void>) | undefined;
+
 /** Set of all result webviews (singleton + results viewer tabs). */
 const resultWebviews = new Set<vscode.WebviewPanel>();
 
@@ -92,7 +95,7 @@ const visibilityOptions = ['Visible', 'Hidden'];
  * - 'data': Only data tables. Tabs shown only if multiple tables.
  * - 'all': Chart, data tables, and query tabs — all visible.
  */
-export type ResultViewMode = 'chart' | 'data' | 'all';
+export type ResultViewMode = 'chart' | 'data' | 'detail' | 'all';
 
 /** Per-viewer state for results viewer webviews. */
 interface ResultViewerState {
@@ -143,9 +146,32 @@ export function activate(context: vscode.ExtensionContext, client: LanguageClien
     );
 
     // Register the bottom-panel WebviewView provider
+    let resolvePanelReady: (() => void) | undefined;
+    let panelReadyPromise: Promise<void> | undefined;
+
+    function createPanelReadyPromise(): Promise<void> {
+        if (!panelReadyPromise) {
+            panelReadyPromise = new Promise<void>(resolve => {
+                resolvePanelReady = resolve;
+            });
+        }
+        return panelReadyPromise;
+    }
+
+    // Expose a function for showPanelHtml to wait on
+    waitForPanelReady = async () => {
+        await vscode.commands.executeCommand('kusto.resultsView.focus');
+        await createPanelReadyPromise();
+    };
+
     vscode.window.registerWebviewViewProvider('kusto.resultsView', {
         resolveWebviewView(webviewView) {
             resultsPanel = webviewView;
+            if (resolvePanelReady) {
+                resolvePanelReady();
+                resolvePanelReady = undefined;
+                panelReadyPromise = undefined;
+            }
             webviewView.webview.options = {
                 enableScripts: true,
                 enableForms: false
@@ -159,6 +185,7 @@ export function activate(context: vscode.ExtensionContext, client: LanguageClien
                     if (match) {
                         panelActiveTabIndex = parseInt(match[1]!, 10);
                     }
+                    vscode.commands.executeCommand('setContext', 'kusto.panelShowingData', message.viewId !== 'query');
                     sendExpressionToResultsPanel();
                 }
                 if (message.command === 'requestExpression') {
@@ -192,7 +219,8 @@ export function activate(context: vscode.ExtensionContext, client: LanguageClien
         }),
         vscode.commands.registerCommand('kusto.saveSingletonResults', () => saveCurrentResults('singleton')),
         vscode.commands.registerCommand('kusto.moveViewToMain', () => moveResultViewToMain()),
-        vscode.commands.registerCommand('kusto.toggleSearch', () => toggleSearch())
+        vscode.commands.registerCommand('kusto.toggleSearch', () => toggleSearch()),
+        vscode.commands.registerCommand('kusto.removeChart', () => removeChart())
     );
 
     // Register results-related commands (previously in resultsPanel)
@@ -670,8 +698,8 @@ export class ResultsViewProvider implements vscode.CustomTextEditorProvider {
         const tables = dataResult?.tables ?? [];
 
         const showChart = hasChart && (mode === 'chart' || mode === 'all');
-        const showTables = mode === 'data' || mode === 'all';
-        const showQuery = !!queryText && mode === 'all';
+        const showTables = mode === 'data' || mode === 'detail' || mode === 'all';
+        const showQuery = !!queryText && (mode === 'detail' || mode === 'all');
 
         // Determine whether to show the tab bar
         const visibleTabCount =
@@ -1925,11 +1953,37 @@ let singletonChartOptionsOverride: server.ChartOptions | undefined;
 /** Debounce timer for singleton chart option changes. */
 let singletonChartOptionsTimer: ReturnType<typeof setTimeout> | undefined;
 
+/** Backing file URI for the singleton view (history file or user-saved file). */
+let singletonBackingUri: vscode.Uri | undefined;
+
+/** Debounce timer for writing back to the singleton backing file. */
+let singletonWriteBackTimer: ReturnType<typeof setTimeout> | undefined;
+
+/** The mode the singleton view was last opened with. */
+let singletonMode: ResultViewMode | undefined;
+
 /**
  * Returns whether the singleton result viewer currently exists.
  */
 export function hasSingletonResultsView(): boolean {
     return singletonView !== undefined;
+}
+
+/**
+ * Sets the backing file URI for the singleton view.
+ * Flushes any pending write-back to the previous URI before switching.
+ */
+export function setSingletonBackingUri(uri: vscode.Uri | undefined): void {
+    // Flush pending writes to the OLD backing file before switching
+    flushSingletonWriteBack();
+    singletonBackingUri = uri;
+}
+
+/**
+ * Returns the language client for use by other modules.
+ */
+export function getLanguageClient(): LanguageClient {
+    return languageClient;
 }
 
 /**
@@ -1956,6 +2010,8 @@ export async function displayResultsInPanel(
 
     lastPanelResultData = resultData;
     panelActiveTabIndex = 0;
+    // Default to showing data (first tab is always a data tab, not query)
+    vscode.commands.executeCommand('setContext', 'kusto.panelShowingData', true);
 
     const darkMode = isDarkMode();
 
@@ -2016,7 +2072,11 @@ async function showPanelHtml(html: string, rowCount?: number, hasError?: boolean
         if (isBesideMode) {
             return;
         }
-        await vscode.commands.executeCommand('kusto.resultsView.focus');
+        if (waitForPanelReady) {
+            await waitForPanelReady();
+        } else {
+            await vscode.commands.executeCommand('kusto.resultsView.focus');
+        }
     }
 
     if (!resultsPanel) {
@@ -2098,6 +2158,12 @@ export async function displayResultsInSingletonView(
     mode: ResultViewMode,
     beside: boolean
 ): Promise<void> {
+    // Always update result data before any early-return dispose paths,
+    // so that a write-back in disposeSingletonView won't write stale
+    // data from a previous result to the current backing file.
+    singletonResultData = resultData;
+    singletonChartOptionsOverride = undefined;
+
     if (!resultData?.tables?.length) {
         disposeSingletonView();
         return;
@@ -2107,9 +2173,6 @@ export async function displayResultsInSingletonView(
         disposeSingletonView();
         return;
     }
-
-    singletonResultData = resultData;
-    singletonChartOptionsOverride = undefined;
 
     const darkMode = isDarkMode();
     const chartOptions = resultData.chartOptions;
@@ -2152,6 +2215,7 @@ function singletonTitleForMode(mode: ResultViewMode): string {
     switch (mode) {
         case 'chart': return 'Chart';
         case 'data': return 'Data';
+        case 'detail': return 'Results';
         case 'all': return 'Results';
     }
 }
@@ -2159,6 +2223,7 @@ function singletonTitleForMode(mode: ResultViewMode): string {
 function showSingletonView(html: string, resultData: server.ResultData, tableNames: string[], beside: boolean, mode: ResultViewMode): void {
     const viewColumn = beside ? vscode.ViewColumn.Beside : vscode.ViewColumn.One;
     const title = singletonTitleForMode(mode);
+    singletonMode = mode;
 
     if (!singletonView) {
         singletonView = vscode.window.createWebviewPanel(
@@ -2213,6 +2278,8 @@ function showSingletonView(html: string, resultData: server.ResultData, tableNam
                 if (!message.clientOnly) {
                     singletonChartOptionsTimer = setTimeout(() => updateChartInSingletonView(), 600);
                 }
+                // Write back to the backing file
+                scheduleSingletonWriteBack();
                 return;
             }
             if (message.command === 'editPanelToggled' && typeof message.visible === 'boolean') {
@@ -2228,10 +2295,12 @@ function showSingletonView(html: string, resultData: server.ResultData, tableNam
 
         singletonView.onDidDispose(() => {
             if (singletonChartOptionsTimer) { clearTimeout(singletonChartOptionsTimer); }
+            flushSingletonWriteBack();
             viewerStates.delete(singletonView!);
             singletonView = undefined;
             singletonResultData = undefined;
             singletonChartOptionsOverride = undefined;
+            singletonBackingUri = undefined;
             vscode.commands.executeCommand('setContext', 'kusto.resultViewerHasChart', false);
             vscode.commands.executeCommand('setContext', 'kusto.resultViewerChartActive', false);
             vscode.commands.executeCommand('kusto.singletonViewStateChanged');
@@ -2278,12 +2347,107 @@ async function updateChartInSingletonView(): Promise<void> {
     }
 }
 
+/** Debounced write of singletonResultData back to the backing file. */
+function scheduleSingletonWriteBack(): void {
+    if (!singletonBackingUri || !singletonResultData) { return; }
+    if (singletonWriteBackTimer) { clearTimeout(singletonWriteBackTimer); }
+    singletonWriteBackTimer = setTimeout(() => {
+        singletonWriteBackTimer = undefined;
+        if (singletonBackingUri && singletonResultData) {
+            const content = JSON.stringify(singletonResultData, null, 2);
+            vscode.workspace.fs.writeFile(singletonBackingUri, Buffer.from(content, 'utf-8'));
+        }
+    }, 1000);
+}
+
+/** Immediately flushes any pending write-back to the backing file. */
+function flushSingletonWriteBack(): void {
+    if (singletonWriteBackTimer) {
+        clearTimeout(singletonWriteBackTimer);
+        singletonWriteBackTimer = undefined;
+    }
+    if (singletonBackingUri && singletonResultData) {
+        const content = JSON.stringify(singletonResultData, null, 2);
+        vscode.workspace.fs.writeFile(singletonBackingUri, Buffer.from(content, 'utf-8'));
+    }
+}
+
+/**
+ * Removes the chart from the active results viewer (singleton or document editor).
+ * If the singleton was in 'chart' mode, it is closed.
+ */
+async function removeChart(): Promise<void> {
+    if (!activeResultWebview?.active) { return; }
+
+    if (activeResultWebview === singletonView) {
+        // Singleton viewer: remove chart from the in-memory data
+        if (!singletonResultData) { return; }
+        const updated = { ...singletonResultData };
+        delete updated.chartOptions;
+        singletonResultData = updated;
+        singletonChartOptionsOverride = undefined;
+
+        // Write the update to the backing file
+        scheduleSingletonWriteBack();
+
+        if (singletonMode === 'chart') {
+            // Was showing chart-only — close the singleton
+            disposeSingletonView();
+        } else {
+            // Re-render without the chart
+            const darkMode = isDarkMode();
+            const dataResult = resultDataToHtml(updated);
+            const tableNames = (dataResult?.tables ?? []).map(t => t.name);
+            const columnNames = updated.tables[0]?.columns?.map(c => c.name) ?? [];
+            const html = htmlBuilder.BuildMultiTabbedHtml(dataResult, undefined, false, singletonMode ?? 'all', undefined, columnNames,
+                updated.query, updated.cluster, updated.database, updated.tables);
+            singletonView!.webview.html = injectMessageHandlerScripts(html, false);
+
+            viewerStates.set(singletonView!, {
+                resultData: updated,
+                tableNames,
+                activeView: 'table-0'
+            });
+            vscode.commands.executeCommand('setContext', 'kusto.resultViewerHasChart', false);
+            vscode.commands.executeCommand('setContext', 'kusto.resultViewerChartActive', false);
+        }
+    } else {
+        // Document viewer: remove chartOptions from the document
+        const state = viewerStates.get(activeResultWebview);
+        if (!state) { return; }
+        const updated = { ...state.resultData };
+        delete updated.chartOptions;
+        state.resultData = updated;
+        state.chartOptionsOverride = undefined;
+
+        // Find the backing document and update it
+        for (const doc of vscode.workspace.textDocuments) {
+            try {
+                const parsed = JSON.parse(doc.getText()) as server.ResultData;
+                if (parsed && viewerStates.get(activeResultWebview)?.resultData === updated) {
+                    const content = JSON.stringify(updated, null, 2);
+                    const fullRange = new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length));
+                    const edit = new vscode.WorkspaceEdit();
+                    edit.replace(doc.uri, fullRange, content);
+                    await vscode.workspace.applyEdit(edit);
+                    await doc.save();
+                    break;
+                }
+            } catch { /* not a result document */ }
+        }
+    }
+}
+
 function disposeSingletonView(): void {
     if (singletonView) {
+        // Flush any pending write-back before disposing
+        flushSingletonWriteBack();
         try { singletonView.dispose(); } catch { /* ignore */ }
         singletonView = undefined;
         singletonResultData = undefined;
         singletonChartOptionsOverride = undefined;
+        singletonBackingUri = undefined;
+        singletonMode = undefined;
         vscode.commands.executeCommand('kusto.singletonViewStateChanged');
     }
 }
@@ -2478,9 +2642,8 @@ async function saveCurrentResults(source: 'singleton' | 'panel'): Promise<void> 
 
     const result = await saveResults({ data });
     if (result) {
-        if (source === 'singleton') {
-            disposeSingletonView();
-        }
+        // Open saved file as a document view, but keep the singleton alive
+        // (history entry remains; singleton will be reused on next query or history click)
         await vscode.commands.executeCommand('vscode.openWith', result.uri, 'kusto.resultViewer', viewColumn);
     }
 }

--- a/src/Client/features/scratchPad.ts
+++ b/src/Client/features/scratchPad.ts
@@ -179,7 +179,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     // Create a default scratch pad if none exist yet
     if (getScratchPadFiles().length === 0) {
-        await createScratchPadFile('Query 1.kql');
+        await createScratchPadFile('QuerySet 1.kql');
     }
 }
 
@@ -280,9 +280,9 @@ async function openScratchPadByName(fileName: string): Promise<void> {
 async function openOrCreateDefaultScratchPad(): Promise<void> {
     const files = getScratchPadFiles();
     if (files.length === 0) {
-        await createScratchPadFile('Query 1.kql');
+        await createScratchPadFile('QuerySet 1.kql');
     }
-    const name = files.length > 0 ? files[0] : 'Query 1.kql';
+    const name = files.length > 0 ? files[0] : 'QuerySet 1.kql';
     await openScratchPadByName(name);
 }
 
@@ -290,10 +290,10 @@ async function openOrCreateDefaultScratchPad(): Promise<void> {
 async function createScratchPad(): Promise<void> {
     const existing = getScratchPadFiles();
     let num = 1;
-    while (existing.includes(`Query ${num}.kql`)) {
+    while (existing.includes(`QuerySet ${num}.kql`)) {
         num++;
     }
-    const name = `Query ${num}.kql`;
+    const name = `QuerySet ${num}.kql`;
 
     // Resolve connection to inherit before opening the new document
     const inheritedConnection = await resolveConnectionToInherit();

--- a/src/Client/package.json
+++ b/src/Client/package.json
@@ -236,7 +236,7 @@
       },
       {
         "command": "kusto.newScratchPad",
-        "title": "New Query",
+        "title": "New Query Set",
         "icon": "$(add)"
       },
       {
@@ -253,6 +253,26 @@
         "command": "kusto.renameScratchPad",
         "title": "Rename",
         "icon": "$(edit)"
+      },
+      {
+        "command": "kusto.openHistoryItem",
+        "title": "Open",
+        "icon": "$(go-to-file)"
+      },
+      {
+        "command": "kusto.deleteHistoryItem",
+        "title": "Delete",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "kusto.clearHistory",
+        "title": "Clear History",
+        "icon": "$(clear-all)"
+      },
+      {
+        "command": "kusto.removeChart",
+        "title": "Remove Chart",
+        "icon": "$(close)"
       }
     ],
     "menus": {
@@ -273,8 +293,13 @@
           "group": "navigation@1"
         },
         {
+          "command": "kusto.clearHistory",
+          "when": "view == kusto.history",
+          "group": "navigation@1"
+        },
+        {
           "command": "kusto.copyData",
-          "when": "view == kusto.resultsView",
+          "when": "view == kusto.resultsView && kusto.panelShowingData",
           "group": "navigation@1"
         },
         {
@@ -289,7 +314,7 @@
         },
         {
           "command": "kusto.toggleSearch",
-          "when": "view == kusto.resultsView",
+          "when": "view == kusto.resultsView && kusto.panelShowingData",
           "group": "navigation@4"
         }
       ],
@@ -372,6 +397,16 @@
         {
           "command": "kusto.deleteScratchPad",
           "when": "view == kusto.scratchPads && viewItem == scratchPad",
+          "group": "9_cutcopypaste"
+        },
+        {
+          "command": "kusto.deleteHistoryItem",
+          "when": "view == kusto.history && viewItem == historyItem",
+          "group": "inline"
+        },
+        {
+          "command": "kusto.deleteHistoryItem",
+          "when": "view == kusto.history && viewItem == historyItem",
           "group": "9_cutcopypaste"
         }
       ],
@@ -468,6 +503,10 @@
           "when": "(webviewId == 'kusto' && chartVisible) || (webviewId == 'kusto.resultViewer' && chartVisible)"
         },
         {
+          "command": "kusto.removeChart",
+          "when": "(webviewId == 'kusto' && chartVisible) || (webviewId == 'kusto.resultViewer' && chartVisible)"
+        },
+        {
           "command": "kusto.saveSingletonResults",
           "when": "webviewId == 'kusto' && chartVisible"
         }
@@ -539,8 +578,13 @@
         },
         {
           "id": "kusto.scratchPads",
-          "name": "Queries",
+          "name": "Query Sets",
           "icon": "$(note)"
+        },
+        {
+          "id": "kusto.history",
+          "name": "History",
+          "icon": "$(history)"
         }
       ]
     },


### PR DESCRIPTION
Add history view in kusto explorer activity panel.
History shows the query results of the most recently run queries.
Selecting a history item re-displays the results in the bottom panel and the chart in the beside panel.