### PR TITLE
Add ability to import connections from kusto explorer app

### DIFF
--- a/src/Client/extension.ts
+++ b/src/Client/extension.ts
@@ -15,6 +15,7 @@ import * as dotnet from './features/dotnet'
 import * as resultsCache from './features/resultsCache'
 import * as scratchPad from './features/scratchPad'
 import * as history from './features/history'
+import * as importConnections from './features/importConnections'
 import { SCRATCH_PAD_SCHEME } from './features/scratchPad'
 import { registerEntityDefinitionProvider, ENTITY_DEFINITION_SCHEME } from './features/entityDefinitionProvider'
 import
@@ -134,6 +135,9 @@ export async function activate(context: ExtensionContext)
 
     // activate connections panel and related features
     await conn.activate(context, client);
+
+    // activate import from Kusto Explorer
+    importConnections.activate(context);
 
     // Create status bar item for connection status
     connectionStatusBar.activate(context);

--- a/src/Client/features/connectionsPanel.ts
+++ b/src/Client/features/connectionsPanel.ts
@@ -11,6 +11,7 @@ import { getHostName, isServerGroup } from './connections';
 import type { ServerInfo, ServerGroupInfo } from './connections';
 import type { DatabaseTableInfo, DatabaseColumnInfo, DatabaseFunctionInfo, DatabaseEntityGroupInfo, DatabaseGraphModelInfo } from './server';
 import { ENTITY_DEFINITION_SCHEME } from './entityDefinitionProvider';
+import { promptImportIfAvailable } from './importConnections';
 
 
 // =============================================================================
@@ -202,6 +203,21 @@ export async function activate(context: vscode.ExtensionContext, client: Languag
 
     // Ensure tree is populated after all initialization
     connectionsProvider.refresh();
+
+    // Prompt to import Kusto Explorer connections when the panel becomes visible
+    let importPromptResolved = false;
+    const tryPromptImport = async () => {
+        if (!importPromptResolved) {
+            importPromptResolved = await promptImportIfAvailable();
+        }
+    };
+    context.subscriptions.push(
+        treeView.onDidChangeVisibility((e) => {
+            if (e.visible) { tryPromptImport(); }
+        })
+    );
+    // Also check if the panel is already visible at activation time
+    if (treeView.visible) { tryPromptImport(); }
 
     // Handle tree item expansion events - fetch data for servers (databases fetch in getChildren)
     context.subscriptions.push(
@@ -549,7 +565,7 @@ function getServerKindIcon(serverKind?: string): vscode.ThemeIcon {
     switch (serverKind) {
         case 'Engine':
             return new vscode.ThemeIcon('server'); // Server icon for query engine
-        case 'DataManager':
+        case 'DataManagement':
             return new vscode.ThemeIcon('cloud-upload'); // Cloud upload for data ingestion
         case 'ClusterManager':
             return new vscode.ThemeIcon('settings-gear'); // Gear for cluster management

--- a/src/Client/features/importConnections.ts
+++ b/src/Client/features/importConnections.ts
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import { XMLParser } from 'fast-xml-parser';
+import * as connections from './connections';
+import type { ServerInfo, ServerGroupInfo } from './connections';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Configuration key to suppress the import prompt. */
+const SUPPRESS_IMPORT_SETTING = 'connections.suppressKustoExplorerImportPrompt';
+
+/** Kusto Explorer user data directory name under %LOCALAPPDATA%. */
+const KUSTO_EXPLORER_DIR = 'Kusto.Explorer';
+
+/** Filename for the groups index. */
+const GROUPS_FILE = 'UserConnectionGroups.xml';
+
+/** Default group name used by Kusto Explorer for ungrouped connections. */
+const DEFAULT_GROUP_NAME = 'Connections';
+
+// =============================================================================
+// Module-level State
+// =============================================================================
+
+let extensionContext: vscode.ExtensionContext;
+
+// =============================================================================
+// Activation
+// =============================================================================
+
+/**
+ * Activates the import feature: registers the import command and optionally
+ * prompts the user to import connections from Kusto Explorer.
+ */
+export function activate(context: vscode.ExtensionContext): void {
+    extensionContext = context;
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('kusto.importFromKustoExplorer', () => importFromKustoExplorer()),
+    );
+}
+
+// =============================================================================
+// Auto-detection and Prompting
+// =============================================================================
+
+/**
+ * Checks if Kusto Explorer connections exist and the user hasn't dismissed
+ * the prompt, then offers to import. Only prompts when the user has no
+ * existing connections.
+ * @returns true if the user made a definitive choice (Import or Don't Ask Again),
+ *          false if they dismissed or no prompt was shown.
+ */
+export async function promptImportIfAvailable(): Promise<boolean> {
+    // Only prompt if user has no connections and hasn't suppressed the prompt
+    if (vscode.workspace.getConfiguration('kusto').get<boolean>(SUPPRESS_IMPORT_SETTING)) {
+        return true;
+    }
+
+    const existingConnections = connections.getConfiguredConnections();
+    if (existingConnections.length > 0) {
+        return true;
+    }
+
+    const groupsPath = getGroupsFilePath();
+    if (!groupsPath || !fs.existsSync(groupsPath)) {
+        return true;
+    }
+
+    const choice = await vscode.window.showInformationMessage(
+        'Kusto Explorer connections found. Would you like to import them?',
+        { modal: true },
+        'Import',
+        "Don't Ask Again"
+    );
+
+    if (choice === 'Import') {
+        await importFromKustoExplorer(true);
+        return true;
+    } else if (choice === "Don't Ask Again") {
+        await vscode.workspace.getConfiguration('kusto').update(SUPPRESS_IMPORT_SETTING, true, vscode.ConfigurationTarget.Global);
+        return true;
+    }
+    // Dismissed (no choice) — caller may re-prompt later
+    return false;
+}
+
+// =============================================================================
+// Import Logic
+// =============================================================================
+
+/**
+ * Main import entry point. Reads Kusto Explorer connection files and
+ * adds them to the extension, skipping duplicates.
+ * @param skipConfirm If true, skip the confirmation dialog (used when already confirmed by the auto-prompt).
+ */
+async function importFromKustoExplorer(skipConfirm = false): Promise<void> {
+    const groupsPath = getGroupsFilePath();
+    if (!groupsPath || !fs.existsSync(groupsPath)) {
+        vscode.window.showErrorMessage('No Kusto Explorer installation found.');
+        return;
+    }
+
+    if (!skipConfirm) {
+        const confirm = await vscode.window.showInformationMessage(
+            'Import connections from Kusto Explorer?',
+            { modal: true },
+            'Import'
+        );
+        if (confirm !== 'Import') { return; }
+    }
+
+    try {
+        const groups = parseGroupsXml(await fs.promises.readFile(groupsPath, 'utf-8'));
+        if (groups.length === 0) {
+            vscode.window.showInformationMessage('No connections found in Kusto Explorer.');
+            return;
+        }
+
+        let importedCount = 0;
+        let skippedCount = 0;
+
+        for (const group of groups) {
+            if (!fs.existsSync(group.filePath)) {
+                continue;
+            }
+
+            const xml = await fs.promises.readFile(group.filePath, 'utf-8');
+            const servers = await parseConnectionsXml(xml);
+            if (servers.length === 0) {
+                continue;
+            }
+
+            const isDefaultGroup = group.name === DEFAULT_GROUP_NAME;
+
+            // Ensure the group exists (unless it's the default root group)
+            if (!isDefaultGroup) {
+                const existing = connections.getServersAndGroups();
+                const groupExists = existing.items.some(
+                    item => connections.isServerGroup(item) && item.name === group.name
+                );
+                if (!groupExists) {
+                    const newGroup: ServerGroupInfo = { name: group.name, servers: [] };
+                    await connections.addServerGroup(newGroup);
+                }
+            }
+
+            for (const server of servers) {
+                // Check for duplicates by cluster hostname
+                if (connections.findServerInfo(server.cluster)) {
+                    skippedCount++;
+                    continue;
+                }
+
+                await connections.addServer(server, isDefaultGroup ? undefined : group.name);
+                importedCount++;
+            }
+        }
+
+        if (importedCount > 0) {
+            const skippedMsg = skippedCount > 0 ? ` (${skippedCount} duplicates skipped)` : '';
+            vscode.window.showInformationMessage(
+                `Imported ${importedCount} connection${importedCount !== 1 ? 's' : ''} from Kusto Explorer${skippedMsg}.`
+            );
+        } else if (skippedCount > 0) {
+            vscode.window.showInformationMessage(
+                `All ${skippedCount} Kusto Explorer connection${skippedCount !== 1 ? 's' : ''} already exist.`
+            );
+        } else {
+            vscode.window.showInformationMessage('No connections found in Kusto Explorer.');
+        }
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        vscode.window.showErrorMessage(`Failed to import connections: ${message}`);
+    }
+}
+
+// =============================================================================
+// XML Parsing
+// =============================================================================
+
+const xmlParser = new XMLParser();
+
+/**
+ * Parses UserConnectionGroups.xml to get group names and their connection file paths.
+ */
+function parseGroupsXml(xml: string): { name: string; filePath: string }[] {
+    const doc = xmlParser.parse(xml);
+    const entries = doc?.ArrayOfServerGroupDescription?.ServerGroupDescription;
+    if (!entries) { return []; }
+    const list = Array.isArray(entries) ? entries : [entries];
+    return list
+        .filter((e: any) => e.Name && e.Details)
+        .map((e: any) => ({
+            name: e.Name as string,
+            filePath: e.Details as string,
+        }));
+}
+
+/**
+ * Parses a UserConnections.xml (or group connections file) into ServerInfo[].
+ */
+async function parseConnectionsXml(xml: string): Promise<ServerInfo[]> {
+    const doc = xmlParser.parse(xml);
+    const entries = doc?.ArrayOfServerDescriptionBase?.ServerDescriptionBase;
+    if (!entries) { return []; }
+    const list = Array.isArray(entries) ? entries : [entries];
+
+    const results: ServerInfo[] = [];
+    for (const entry of list) {
+        const connectionString = entry.ConnectionString;
+        if (!connectionString) { continue; }
+
+        const cluster = await connections.getHostName(connectionString);
+        const displayName = entry.Name as string | undefined;
+
+        const server: ServerInfo = {
+            connection: connectionString,
+            cluster,
+        };
+
+        // Use the KE display name if it differs from the cluster hostname
+        if (displayName && displayName !== cluster) {
+            server.displayName = displayName;
+        }
+
+        // Fetch server kind (e.g. DataManager, ClusterManager) from the server API
+        const serverKind = await connections.fetchServerKind(connectionString);
+        if (serverKind) {
+            server.serverKind = serverKind;
+        }
+
+        results.push(server);
+    }
+
+    return results;
+}
+
+// =============================================================================
+// Path Helpers
+// =============================================================================
+
+/**
+ * Returns the path to UserConnectionGroups.xml if it exists, or undefined.
+ */
+function getGroupsFilePath(): string | undefined {
+    const localAppData = process.env.LOCALAPPDATA;
+    if (!localAppData) { return undefined; }
+    return path.join(localAppData, KUSTO_EXPLORER_DIR, GROUPS_FILE);
+}

--- a/src/Client/package-lock.json
+++ b/src/Client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
+        "fast-xml-parser": "^5.5.9",
         "vscode-languageclient": "^9.0.0"
       },
       "devDependencies": {
@@ -517,6 +518,39 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
+      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -636,6 +670,20 @@
         "wrappy": "1"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -727,6 +775,17 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",

--- a/src/Client/package.json
+++ b/src/Client/package.json
@@ -273,6 +273,11 @@
         "command": "kusto.removeChart",
         "title": "Remove Chart",
         "icon": "$(close)"
+      },
+      {
+        "command": "kusto.importFromKustoExplorer",
+        "title": "Import from Kusto Explorer",
+        "icon": "$(cloud-download)"
       }
     ],
     "menus": {
@@ -286,6 +291,11 @@
           "command": "kusto.addServerGroup",
           "when": "view == kusto.connections",
           "group": "navigation@2"
+        },
+        {
+          "command": "kusto.importFromKustoExplorer",
+          "when": "view == kusto.connections",
+          "group": "navigation@3"
         },
         {
           "command": "kusto.newScratchPad",
@@ -610,6 +620,11 @@
             "type": "string",
             "default": ".kusto.windows.net",
             "description": "The domain appended to abbreviated cluster names in cluster() expressions."
+          },
+          "kusto.connections.suppressKustoExplorerImportPrompt": {
+            "type": "boolean",
+            "default": false,
+            "description": "Suppress the prompt to import connections from Kusto Explorer when no connections are configured."
           }
         }
       },
@@ -1545,6 +1560,7 @@
     ]
   },
   "dependencies": {
+    "fast-xml-parser": "^5.5.9",
     "vscode-languageclient": "^9.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request introduces a new feature to import connections from Kusto Explorer into the extension, along with some supporting changes and minor fixes. The main change is the addition of an import workflow that detects existing Kusto Explorer connections and prompts the user to import them if no connections are configured. This improves onboarding for users migrating from Kusto Explorer. Additional changes update dependencies and fix a minor icon mapping issue.
