### PR TITLE
Import scratch pads from Kusto Explorer

### DIFF
--- a/src/Client/extension.ts
+++ b/src/Client/extension.ts
@@ -15,7 +15,7 @@ import * as dotnet from './features/dotnet'
 import * as resultsCache from './features/resultsCache'
 import * as scratchPad from './features/scratchPad'
 import * as history from './features/history'
-import * as importConnections from './features/importConnections'
+import * as importFeature from './features/import'
 import { SCRATCH_PAD_SCHEME } from './features/scratchPad'
 import { registerEntityDefinitionProvider, ENTITY_DEFINITION_SCHEME } from './features/entityDefinitionProvider'
 import
@@ -137,7 +137,7 @@ export async function activate(context: ExtensionContext)
     await conn.activate(context, client);
 
     // activate import from Kusto Explorer
-    importConnections.activate(context);
+    importFeature.activate(context);
 
     // Create status bar item for connection status
     connectionStatusBar.activate(context);

--- a/src/Client/features/clientStorage.ts
+++ b/src/Client/features/clientStorage.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module bridges the language server and VS Code's persistent storage.
+ * The server sends kusto/getData and kusto/setData requests, and this module reads from or writes to
+ * the extension's globalState in response, allowing the server to persist data across sessions.
+ */
+
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 

--- a/src/Client/features/clipboard.ts
+++ b/src/Client/features/clipboard.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module manages clipboard operations with rich context metadata.
+ * When content is copied (e.g. an entity name or query), it stores the source connection and entity info
+ * alongside the clipboard text, enabling context-aware paste behavior.
+ */
+
 import * as vscode from 'vscode';
 
 /** Generic clipboard context that can carry arbitrary metadata. */

--- a/src/Client/features/completion.ts
+++ b/src/Client/features/completion.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module fixes a VS Code/LSP completion edge case where commit characters (e.g. '(' or '.')
+ * that also appear in the inserted text get doubled. It attaches a post-completion command to detect
+ * and remove the duplicate character.
+ */
+
 import * as vscode from 'vscode';
 
 /**

--- a/src/Client/features/connectionStatusBar.ts
+++ b/src/Client/features/connectionStatusBar.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module manages the status bar item that shows the active document's Kusto connection.
+ * It displays the current cluster and database, and updates automatically when the active editor
+ * or its connection changes.
+ */
+
 import * as vscode from 'vscode';
 import * as connections from './connections';
 

--- a/src/Client/features/connections.ts
+++ b/src/Client/features/connections.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module manages the data layer for Kusto server connections and per-document connection assignments.
+ * Connections (servers and groups) are persisted in globalState; document-to-connection mappings are in workspaceState.
+ * It also provides database schema caching and event notifications when connections change.
+ */
+
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import * as lspServer from './server';

--- a/src/Client/features/connectionsPanel.ts
+++ b/src/Client/features/connectionsPanel.ts
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module implements the "Connections" tree view in the sidebar.
+ * It displays configured Kusto clusters, databases, and schema entities (tables, functions, etc.),
+ * and provides commands for adding, removing, editing, and browsing connections.
+ * On first activation with no connections, it prompts the user to import from Kusto Explorer.
+ */
+
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import * as lspServer from './server';
@@ -11,7 +18,7 @@ import { getHostName, isServerGroup } from './connections';
 import type { ServerInfo, ServerGroupInfo } from './connections';
 import type { DatabaseTableInfo, DatabaseColumnInfo, DatabaseFunctionInfo, DatabaseEntityGroupInfo, DatabaseGraphModelInfo } from './server';
 import { ENTITY_DEFINITION_SCHEME } from './entityDefinitionProvider';
-import { promptImportIfAvailable } from './importConnections';
+import { promptImportIfAvailable } from './import';
 
 
 // =============================================================================

--- a/src/Client/features/copilot.ts
+++ b/src/Client/features/copilot.ts
@@ -1,6 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module implements the @kusto chat participant and language model tools for GitHub Copilot.
+ * It registers tools for querying cluster metadata, running queries, validating KQL, and inspecting schema,
+ * enabling Copilot to assist users with Kusto queries using their connected database context.
+ */
+
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import * as conn from './connections';

--- a/src/Client/features/dotnet.ts
+++ b/src/Client/features/dotnet.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module acquires the .NET runtime needed to run the Kusto Language Server.
+ * It first checks for a system-installed dotnet (version 10+), and falls back to the
+ * VS Code .NET Runtime Acquisition extension if not found or if the user has opted out.
+ */
+
 import * as vscode from 'vscode';
 import { execFile } from 'child_process';
 import { promisify } from 'util';

--- a/src/Client/features/entityDefinitionProvider.ts
+++ b/src/Client/features/entityDefinitionProvider.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module provides "Go to Definition" for Kusto database entities (tables, functions, etc.).
+ * When the language server resolves a definition to a kusto-entity:// URI, this provider fetches
+ * the entity's create command from the server and displays it as a read-only virtual document.
+ */
+
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { EntityDefinitionContentResult } from './server';

--- a/src/Client/features/history.ts
+++ b/src/Client/features/history.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module implements query history, recording each executed query with its connection context.
+ * History entries are stored as individual .kql files in globalStorage, with a lightweight JSON index
+ * for the tree view. The "History" tree view in the sidebar lets users browse, open, and delete past queries.
+ */
+
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';

--- a/src/Client/features/html.ts
+++ b/src/Client/features/html.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module converts query result data into HTML tables for clipboard copy operations.
+ * It renders ResultData into styled HTML with configurable table, header, and cell attributes,
+ * and is used when copying query results with formatting (e.g. paste into Excel or email).
+ */
+
 import { ResultData, ResultTable } from './server';
 
 /** A single HTML table from the query result. */

--- a/src/Client/features/import.ts
+++ b/src/Client/features/import.ts
@@ -1,12 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module implements importing data from Kusto Explorer, the desktop application for Azure Data Explorer.
+ * It supports importing both connections (from UserConnectionGroups.xml) and scratch pad query documents (from .kebak recovery files).
+ * On first activation, if no connections exist, it auto-prompts the user to import from Kusto Explorer.
+ */
+
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { XMLParser } from 'fast-xml-parser';
 import * as connections from './connections';
 import type { ServerInfo, ServerGroupInfo } from './connections';
+import { addScratchPadFile } from './scratchPad';
 
 // =============================================================================
 // Constants
@@ -23,6 +30,12 @@ const GROUPS_FILE = 'UserConnectionGroups.xml';
 
 /** Default group name used by Kusto Explorer for ungrouped connections. */
 const DEFAULT_GROUP_NAME = 'Connections';
+
+/** Recovery directory under Kusto Explorer for scratch pad backup files. */
+const RECOVERY_DIR = 'Recovery';
+
+/** Extension for Kusto Explorer scratch pad backup files. */
+const RECOVERY_EXT = '.kebak';
 
 // =============================================================================
 // Module-level State
@@ -42,7 +55,8 @@ export function activate(context: vscode.ExtensionContext): void {
     extensionContext = context;
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('kusto.importFromKustoExplorer', () => importFromKustoExplorer()),
+        vscode.commands.registerCommand('kusto.importConnectionsFromKustoExplorer', () => importConnectionsFromKustoExplorer()),
+        vscode.commands.registerCommand('kusto.importScratchPadsFromKustoExplorer', () => importAllScratchPads()),
     );
 }
 
@@ -68,20 +82,31 @@ export async function promptImportIfAvailable(): Promise<boolean> {
         return true;
     }
 
-    const groupsPath = getGroupsFilePath();
-    if (!groupsPath || !fs.existsSync(groupsPath)) {
+    const hasConnections = hasKustoExplorerConnections();
+    const hasScratchPads = hasKustoExplorerScratchPads();
+
+    if (!hasConnections && !hasScratchPads) {
         return true;
     }
 
+    const what = hasConnections && hasScratchPads ? 'connections and query set documents'
+        : hasConnections ? 'connections' 
+        : 'query set documents';
+
     const choice = await vscode.window.showInformationMessage(
-        'Kusto Explorer connections found. Would you like to import them?',
+        `Kusto Explorer ${what} found. Would you like to import them?`,
         { modal: true },
         'Import',
         "Don't Ask Again"
     );
 
     if (choice === 'Import') {
-        await importFromKustoExplorer(true);
+        if (hasConnections) {
+            await importConnectionsFromKustoExplorer(true);
+        }
+        if (hasScratchPads) {
+            await importAllScratchPads(true);
+        }
         return true;
     } else if (choice === "Don't Ask Again") {
         await vscode.workspace.getConfiguration('kusto').update(SUPPRESS_IMPORT_SETTING, true, vscode.ConfigurationTarget.Global);
@@ -92,15 +117,15 @@ export async function promptImportIfAvailable(): Promise<boolean> {
 }
 
 // =============================================================================
-// Import Logic
+// Import Connections
 // =============================================================================
 
 /**
- * Main import entry point. Reads Kusto Explorer connection files and
+ * Main connections import entry point. Reads Kusto Explorer connection files and
  * adds them to the extension, skipping duplicates.
  * @param skipConfirm If true, skip the confirmation dialog (used when already confirmed by the auto-prompt).
  */
-async function importFromKustoExplorer(skipConfirm = false): Promise<void> {
+async function importConnectionsFromKustoExplorer(skipConfirm = false): Promise<void> {
     const groupsPath = getGroupsFilePath();
     if (!groupsPath || !fs.existsSync(groupsPath)) {
         vscode.window.showErrorMessage('No Kusto Explorer installation found.');
@@ -182,7 +207,171 @@ async function importFromKustoExplorer(skipConfirm = false): Promise<void> {
 }
 
 // =============================================================================
-// XML Parsing
+// Import Scratch Pads
+// =============================================================================
+
+/** Shape of a Kusto Explorer scratch pad recovery (.kebak) file. */
+interface KustoExplorerRecoveryFile {
+    CustomTitle?: string;
+    QueryText?: string;
+    ConnectionString?: string;
+    TabOrdinal?: number;
+    FullPath?: string;
+}
+
+/**
+ * Imports all scratch pad documents from Kusto Explorer.
+ * @param skipConfirm If true, skip the confirmation dialog (used when already confirmed by the auto-prompt).
+ */
+async function importAllScratchPads(skipConfirm = false): Promise<void> {
+    const recoveryFiles = getScratchPadRecoveryFiles();
+    if (!recoveryFiles) {
+        vscode.window.showInformationMessage('No Kusto Explorer scratch pad documents found to import.');
+        return;
+    }
+
+    if (!skipConfirm) {
+        const confirm = await vscode.window.showInformationMessage(
+            `Import ${recoveryFiles.length} scratch pad document${recoveryFiles.length !== 1 ? 's' : ''} from Kusto Explorer?`,
+            { modal: true },
+            'Import'
+        );
+        if (confirm !== 'Import') { return; }
+    }
+
+    const importedCount = await importRecoveryFilesAsScratchPads(recoveryFiles);
+
+    if (importedCount > 0) {
+        vscode.window.showInformationMessage(
+            `Imported ${importedCount} scratch pad document${importedCount !== 1 ? 's' : ''} from Kusto Explorer.`
+        );
+    }
+}
+
+/**
+ * Gets a list of all recovery files from Kusto Explorer that appear to be scratch pad documents.
+ */
+function getScratchPadRecoveryFiles(): KustoExplorerRecoveryFile[] | undefined {
+    const recoveryDir = getRecoveryDirPath();
+    if (!recoveryDir || !fs.existsSync(recoveryDir)) {
+        return undefined;
+    }
+
+    const kebakFiles = fs.readdirSync(recoveryDir).filter(f => f.endsWith(RECOVERY_EXT));
+    if (kebakFiles.length === 0) {
+        return undefined;
+    }
+
+    const entries: KustoExplorerRecoveryFile[] = [];
+    for (const file of kebakFiles) {
+        try {
+            const raw = fs.readFileSync(path.join(recoveryDir, file), 'utf-8');
+            const entry: KustoExplorerRecoveryFile = JSON.parse(raw);
+            // Only import scratch pad documents (no FullPath). Files with a
+            // FullPath were already saved to disk and are just recovery backups.
+            if (entry.QueryText?.trim() && !entry.FullPath?.trim()) {
+                entries.push(entry);
+            }
+        } catch {
+            // Skip malformed files
+        }
+    }
+
+    if (entries.length === 0) {
+        return undefined;
+    }
+
+    // Sort by tab ordinal to preserve the user's tab order
+    entries.sort((a, b) => (a.TabOrdinal ?? 0) - (b.TabOrdinal ?? 0));
+    return entries;
+}
+
+/**
+ * Imports a list of recovery files as scratch pad files.
+ * Returns the number of successfully imported entries.
+ */
+async function importRecoveryFilesAsScratchPads(recoveryFiles: KustoExplorerRecoveryFile[]): Promise<number> {
+    let importedCount = 0;
+    for (const recoveryFile of recoveryFiles) {
+        // Resolve the connection first so we can use the friendly name for naming
+        let cluster: string | undefined;
+        let database: string | undefined;
+        if (recoveryFile.ConnectionString) {
+            try {
+                cluster = await connections.getHostName(recoveryFile.ConnectionString);
+                database = parseDatabaseFromConnectionString(recoveryFile.ConnectionString);
+                if (cluster && !connections.findServerInfo(cluster)) {
+                    const server: ServerInfo = {
+                        connection: recoveryFile.ConnectionString,
+                        cluster,
+                    };
+                    const serverKind = await connections.fetchServerKind(recoveryFile.ConnectionString);
+                    if (serverKind) {
+                        server.serverKind = serverKind;
+                    }
+                    await connections.addServer(server);
+                }
+            } catch {
+                // Connection resolution is best-effort; don't block import
+            }
+        }
+
+        // Determine the scratch pad name:
+        // 1. Use CustomTitle if the user named it
+        // 2. Derive from connection.database (matching Kusto Explorer's convention)
+        // 3. Fall back to auto-naming (ScratchPad<N>)
+        const customTitle = recoveryFile.CustomTitle?.trim() || null;
+        let name: string | null;
+        if (customTitle) {
+            name = sanitizeFileName(customTitle);
+        } else if (cluster) {
+            const serverInfo = connections.findServerInfo(cluster);
+            const connectionName = serverInfo?.displayName ?? cluster;
+            name = database ? sanitizeFileName(`${connectionName}.${database}`) : sanitizeFileName(connectionName);
+        } else {
+            name = null;
+        }
+
+        const finalName = await addScratchPadFile(name, recoveryFile.QueryText!);
+
+        // Associate the connection with the new scratch pad
+        if (cluster) {
+            try {
+                const scratchUri = `kusto-scratch:/${finalName}`;
+                await connections.setDocumentConnection(scratchUri, cluster, database);
+            } catch {
+                // Connection association is best-effort; don't block import
+            }
+        }
+
+        importedCount++;
+    }
+    return importedCount;
+}
+
+/**
+ * Sanitizes a string for use as a filename by removing characters
+ * that are invalid on Windows/macOS/Linux.
+ */
+function sanitizeFileName(name: string): string {
+    return name.replace(/[<>:"/\\|?*]/g, '_').replace(/\s+/g, ' ').trim() || 'ScratchPad';
+}
+
+/**
+ * Extracts the database name (Initial Catalog) from a Kusto connection string.
+ * Returns undefined if the database is "NetDefaultDB" (Kusto Explorer's placeholder).
+ */
+function parseDatabaseFromConnectionString(connectionString: string): string | undefined {
+    const match = connectionString.match(/Initial Catalog\s*=\s*([^;]+)/i);
+    const database = match?.[1]?.trim();
+    if (!database || database === 'NetDefaultDB') {
+        return undefined;
+    }
+    return database;
+}
+
+// =============================================================================
+// Connection XML Parsing
 // =============================================================================
 
 const xmlParser = new XMLParser();
@@ -253,4 +442,26 @@ function getGroupsFilePath(): string | undefined {
     const localAppData = process.env.LOCALAPPDATA;
     if (!localAppData) { return undefined; }
     return path.join(localAppData, KUSTO_EXPLORER_DIR, GROUPS_FILE);
+}
+
+/**
+ * Returns the path to the Kusto Explorer Recovery directory, or undefined.
+ */
+function getRecoveryDirPath(): string | undefined {
+    const localAppData = process.env.LOCALAPPDATA;
+    if (!localAppData) { return undefined; }
+    return path.join(localAppData, KUSTO_EXPLORER_DIR, RECOVERY_DIR);
+}
+
+/** Returns true if Kusto Explorer connection files exist on disk. */
+function hasKustoExplorerConnections(): boolean {
+    const groupsPath = getGroupsFilePath();
+    return !!groupsPath && fs.existsSync(groupsPath);
+}
+
+/** Returns true if Kusto Explorer scratch pad recovery files exist on disk. */
+function hasKustoExplorerScratchPads(): boolean {
+    const recoveryDir = getRecoveryDirPath();
+    if (!recoveryDir || !fs.existsSync(recoveryDir)) { return false; }
+    return fs.readdirSync(recoveryDir).some(f => f.endsWith(RECOVERY_EXT));
 }

--- a/src/Client/features/markdown.ts
+++ b/src/Client/features/markdown.ts
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module converts query result data into markdown table format.
+ * It is used by the Copilot integration to return query results as readable markdown text.
+ */
+
 import { ResultData, ResultTable } from './server';
 
 /**

--- a/src/Client/features/queryDocuments.ts
+++ b/src/Client/features/queryDocuments.ts
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+ * This module implements query execution and the editor experience for .kql documents.
+ * It provides CodeLens actions (Run, Format, Copy, Results) above each query, handles query execution
+ * via the language server, manages result display, and adds visual elements like query separator
+ * decorations, semantic token coloring, error range markers, and context-aware paste.
+ */
+
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { setDocumentConnection, ensureServer, getDocumentConnection } from './connections';

--- a/src/Client/features/scratchPad.ts
+++ b/src/Client/features/scratchPad.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/*
+* This module implements the "Query Sets" feature in the sidebar. 
+* Each query set is considered a scratch pad - a temporary workspace for Kusto queries that isn't part of the user's source code project,
+* but instead a .kql file stored in a space provided by the extension.
+*/
+
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -12,6 +18,12 @@ import * as connections from './connections';
 
 /** URI scheme for scratch pad virtual documents. */
 export const SCRATCH_PAD_SCHEME = 'kusto-scratch';
+
+/** Name of the JSON file that stores scratch pad display order. */
+const ORDER_FILE = '_order.json';
+
+/** MIME type for scratch pad drag-and-drop within the tree view. */
+const SCRATCH_PAD_DRAG_MIME = 'application/vnd.code.tree.kusto.scratchPads';
 
 // =============================================================================
 // Module-level State
@@ -40,14 +52,14 @@ const placeholderDecoration = vscode.window.createTextEditorDecorationType({
 // URI Helpers
 // =============================================================================
 
-/** Builds a virtual URI for a scratch pad file: kusto-scratch:/Scratch 1.kql */
+/** Builds a virtual URI for a scratch pad file: kusto-scratch:/ScratchPad1.kql */
 function scratchUri(fileName: string): vscode.Uri {
     return vscode.Uri.from({ scheme: SCRATCH_PAD_SCHEME, path: '/' + fileName });
 }
 
 /** Resolves a virtual URI to its backing file path on disk. */
 function diskPath(uri: vscode.Uri): string {
-    // uri.path is like "/Scratch 1.kql" — strip the leading slash
+    // uri.path is like "/ScratchPad1.kql" — strip the leading slash
     const fileName = uri.path.replace(/^\//, '');
     return path.join(scratchpadDir, fileName);
 }
@@ -133,10 +145,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.workspace.registerFileSystemProvider(SCRATCH_PAD_SCHEME, scratchFs)
     );
 
-    // Register tree data provider
+    // Register tree data provider with drag and drop support
     treeProvider = new ScratchPadTreeProvider();
     treeView = vscode.window.createTreeView('kusto.scratchPads', {
         treeDataProvider: treeProvider,
+        dragAndDropController: new ScratchPadDragAndDropController(),
     });
     context.subscriptions.push(treeView);
 
@@ -179,7 +192,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     // Create a default scratch pad if none exist yet
     if (getScratchPadFiles().length === 0) {
-        await createScratchPadFile('QuerySet 1.kql');
+        await createScratchPadFile(nextScratchPadFileName([]));
     }
 }
 
@@ -187,22 +200,119 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 // File Helpers
 // =============================================================================
 
-/** Returns sorted list of .kql filenames in the scratchpads directory. */
+/** Returns ordered list of .kql filenames in the scratchpads directory, respecting user-defined order. */
 function getScratchPadFiles(): string[] {
     if (!fs.existsSync(scratchpadDir)) {
         return [];
     }
-    return fs.readdirSync(scratchpadDir)
-        .filter(f => f.endsWith('.kql'))
-        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+    const filesOnDisk = fs.readdirSync(scratchpadDir)
+        .filter(f => f.endsWith('.kql'));
+    if (filesOnDisk.length === 0) {
+        return [];
+    }
+    const order = readOrder();
+    return reconcileOrder(order, filesOnDisk);
 }
 
-/** Creates an empty .kql file in the scratchpads directory if it doesn't exist. */
+/** Reads the order list from disk. Returns an empty array if the file doesn't exist or is invalid. */
+function readOrder(): string[] {
+    const orderPath = path.join(scratchpadDir, ORDER_FILE);
+    try {
+        const data = fs.readFileSync(orderPath, 'utf-8');
+        const parsed = JSON.parse(data);
+        if (Array.isArray(parsed) && parsed.every(item => typeof item === 'string')) {
+            return parsed;
+        }
+    } catch {
+        // File missing or invalid — return empty
+    }
+    return [];
+}
+
+/** Writes the order list to disk. */
+function saveOrder(order: string[]): void {
+    const orderPath = path.join(scratchpadDir, ORDER_FILE);
+    fs.writeFileSync(orderPath, JSON.stringify(order, null, 2), 'utf-8');
+}
+
+/**
+ * Reconciles the persisted order with actual files on disk.
+ * - Preserves order for files that still exist
+ * - Removes entries for files that no longer exist on disk
+ * - Appends any new files not in the order list to the end
+ * Saves the reconciled order if it changed.
+ */
+function reconcileOrder(order: string[], filesOnDisk: string[]): string[] {
+    const diskSet = new Set(filesOnDisk);
+    const orderSet = new Set(order);
+
+    // Keep only entries that still exist on disk
+    const reconciled = order.filter(f => diskSet.has(f));
+
+    // Append any files on disk that aren't in the order list (sorted for determinism on first migration)
+    const newFiles = filesOnDisk.filter(f => !orderSet.has(f))
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+    reconciled.push(...newFiles);
+
+    // Save if the order changed
+    if (reconciled.length !== order.length || reconciled.some((f, i) => f !== order[i])) {
+        saveOrder(reconciled);
+    }
+
+    return reconciled;
+}
+
+/** Returns the next available ScratchPad filename (e.g. "ScratchPad1.kql") that doesn't conflict with existing files. */
+function nextScratchPadFileName(existing: string[]): string {
+    let num = 1;
+    while (existing.includes(`ScratchPad${num}.kql`)) {
+        num++;
+    }
+    return `ScratchPad${num}.kql`;
+}
+
+/** Creates an empty .kql file in the scratchpads directory if it doesn't exist, and appends to order. */
 async function createScratchPadFile(name: string): Promise<void> {
     const filePath = path.join(scratchpadDir, name);
     if (!fs.existsSync(filePath)) {
         await fs.promises.writeFile(filePath, '', 'utf-8');
     }
+    const order = readOrder();
+    if (!order.includes(name)) {
+        order.push(name);
+        saveOrder(order);
+    }
+}
+
+/**
+ * Adds a scratch pad file with the given name and content.
+ * If name is null, the next available ScratchPad name is used.
+ * If a file with the same name already exists, a numeric suffix is added.
+ * Returns the final filename used.
+ */
+export async function addScratchPadFile(name: string | null, content: string): Promise<string> {
+    const existing = getScratchPadFiles();
+    let finalName = name ?? nextScratchPadFileName(existing);
+    if (!finalName.endsWith('.kql')) {
+        finalName += '.kql';
+    }
+    if (existing.includes(finalName)) {
+        const base = path.basename(finalName, '.kql');
+        let num = 2;
+        while (existing.includes(`${base} (${num}).kql`)) {
+            num++;
+        }
+        finalName = `${base} (${num}).kql`;
+    }
+    const filePath = path.join(scratchpadDir, finalName);
+    await fs.promises.writeFile(filePath, content, 'utf-8');
+    const order = readOrder();
+    if (!order.includes(finalName)) {
+        order.push(finalName);
+        saveOrder(order);
+    }
+    treeProvider.refresh();
+    return finalName;
 }
 
 function hasActiveKustoDocument(): boolean {
@@ -279,21 +389,20 @@ async function openScratchPadByName(fileName: string): Promise<void> {
 /** Opens or creates the first scratch pad. */
 async function openOrCreateDefaultScratchPad(): Promise<void> {
     const files = getScratchPadFiles();
-    if (files.length === 0) {
-        await createScratchPadFile('QuerySet 1.kql');
+    let name: string;
+    if (files.length > 0) {
+        name = files[0]!;
+    } else {
+        name = nextScratchPadFileName([]);
+        await createScratchPadFile(name);
     }
-    const name = files.length > 0 ? files[0] : 'QuerySet 1.kql';
     await openScratchPadByName(name);
 }
 
 /** Creates a new scratch pad with the lowest available number. */
 async function createScratchPad(): Promise<void> {
     const existing = getScratchPadFiles();
-    let num = 1;
-    while (existing.includes(`QuerySet ${num}.kql`)) {
-        num++;
-    }
-    const name = `QuerySet ${num}.kql`;
+    const name = nextScratchPadFileName(existing);
 
     // Resolve connection to inherit before opening the new document
     const inheritedConnection = await resolveConnectionToInherit();
@@ -337,6 +446,12 @@ async function deleteScratchPad(item: ScratchPadItem): Promise<void> {
     }
 
     scratchFs.delete(uri);
+    const order = readOrder();
+    const idx = order.indexOf(item.fileName);
+    if (idx !== -1) {
+        order.splice(idx, 1);
+        saveOrder(order);
+    }
     treeProvider.refresh();
 }
 
@@ -382,8 +497,14 @@ async function renameScratchPad(item: ScratchPadItem): Promise<void> {
         }
     }
 
-    // Rename the backing file
+    // Rename the backing file and update the order in-place
     scratchFs.rename(oldUri, newUri);
+    const order = readOrder();
+    const idx = order.indexOf(item.fileName);
+    if (idx !== -1) {
+        order[idx] = newFileName;
+        saveOrder(order);
+    }
     treeProvider.refresh();
 
     // Re-open under the new URI in the same column
@@ -413,22 +534,54 @@ async function saveScratchPadAs(): Promise<void> {
         return;
     }
 
+    // Capture the scratch pad's connection info before any changes
+    const scratchConnection = await connections.getDocumentConnection(scratchUriValue.toString());
+
     // Write content to the new file location
     const content = Buffer.from(scratchDocument.getText(), 'utf-8');
     await vscode.workspace.fs.writeFile(target, content);
 
-    // Close the scratch pad tab
-    for (const tabGroup of vscode.window.tabGroups.all) {
-        for (const tab of tabGroup.tabs) {
-            if (tab.input instanceof vscode.TabInputText && tab.input.uri.toString() === scratchUriValue.toString()) {
-                await vscode.window.tabGroups.close(tab);
-            }
-        }
+    // Transfer connection info to the new file
+    if (scratchConnection?.cluster) {
+        await connections.setDocumentConnection(target.toString(), scratchConnection.cluster, scratchConnection.database);
     }
 
-    // Delete the scratch pad backing file
-    scratchFs.delete(scratchUriValue);
-    treeProvider.refresh();
+    // Ask the user what to do with the original scratch pad
+    const action = await vscode.window.showInformationMessage(
+        `What would you like to do with the original query set "${path.basename(scratchUriValue.path, '.kql')}"?`,
+        { modal: true },
+        'Keep',
+        'Keep and Clear',
+        'Remove',
+    );
+    if (!action) {
+        // User dismissed the dialog — just open the saved file, keep scratch pad as-is
+        const newDoc = await vscode.workspace.openTextDocument(target);
+        await vscode.window.showTextDocument(newDoc, viewColumn);
+        return;
+    }
+
+    if (action === 'Remove') {
+        // Close the scratch pad tab and delete it
+        for (const tabGroup of vscode.window.tabGroups.all) {
+            for (const tab of tabGroup.tabs) {
+                if (tab.input instanceof vscode.TabInputText && tab.input.uri.toString() === scratchUriValue.toString()) {
+                    await vscode.window.tabGroups.close(tab);
+                }
+            }
+        }
+        scratchFs.delete(scratchUriValue);
+        const order = readOrder();
+        const orderIdx = order.indexOf(path.basename(scratchUriValue.path.replace(/^\//, '')));
+        if (orderIdx !== -1) {
+            order.splice(orderIdx, 1);
+            saveOrder(order);
+        }
+        treeProvider.refresh();
+    } else if (action === 'Keep and Clear') {
+        // Clear the scratch pad content
+        scratchFs.writeFile(scratchUriValue, new Uint8Array(), { create: false, overwrite: true });
+    }
 
     // Open the new file in the same column
     const newDoc = await vscode.workspace.openTextDocument(target);
@@ -453,6 +606,46 @@ class ScratchPadTreeProvider implements vscode.TreeDataProvider<ScratchPadItem> 
 
     getChildren(): ScratchPadItem[] {
         return getScratchPadFiles().map(f => new ScratchPadItem(f));
+    }
+}
+
+// =============================================================================
+// Drag and Drop Controller
+// =============================================================================
+
+class ScratchPadDragAndDropController implements vscode.TreeDragAndDropController<ScratchPadItem> {
+    readonly dropMimeTypes = [SCRATCH_PAD_DRAG_MIME];
+    readonly dragMimeTypes = [SCRATCH_PAD_DRAG_MIME];
+
+    handleDrag(source: readonly ScratchPadItem[], dataTransfer: vscode.DataTransfer): void {
+        if (source.length === 1) {
+            dataTransfer.set(SCRATCH_PAD_DRAG_MIME, new vscode.DataTransferItem(source[0]!.fileName));
+        }
+    }
+
+    async handleDrop(target: ScratchPadItem | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
+        const transferItem = dataTransfer.get(SCRATCH_PAD_DRAG_MIME);
+        if (!transferItem || !target) {
+            return;
+        }
+
+        const draggedFileName = transferItem.value as string;
+        if (draggedFileName === target.fileName) {
+            return;
+        }
+
+        const order = readOrder();
+        const fromIndex = order.indexOf(draggedFileName);
+        const toIndex = order.indexOf(target.fileName);
+        if (fromIndex === -1 || toIndex === -1) {
+            return;
+        }
+
+        // Remove from old position and insert at new position
+        order.splice(fromIndex, 1);
+        order.splice(toIndex, 0, draggedFileName);
+        saveOrder(order);
+        treeProvider.refresh();
     }
 }
 

--- a/src/Client/package.json
+++ b/src/Client/package.json
@@ -236,7 +236,7 @@
       },
       {
         "command": "kusto.newScratchPad",
-        "title": "New Query Set",
+        "title": "New Scratch Pad",
         "icon": "$(add)"
       },
       {
@@ -275,8 +275,13 @@
         "icon": "$(close)"
       },
       {
-        "command": "kusto.importFromKustoExplorer",
-        "title": "Import from Kusto Explorer",
+        "command": "kusto.importConnectionsFromKustoExplorer",
+        "title": "Import Connections",
+        "icon": "$(cloud-download)"
+      },
+      {
+        "command": "kusto.importScratchPadsFromKustoExplorer",
+        "title": "Import Scratch Pads",
         "icon": "$(cloud-download)"
       }
     ],
@@ -293,14 +298,44 @@
           "group": "navigation@2"
         },
         {
-          "command": "kusto.importFromKustoExplorer",
+          "command": "kusto.importConnectionsFromKustoExplorer",
           "when": "view == kusto.connections",
           "group": "navigation@3"
+        },
+        {
+          "command": "kusto.addServer",
+          "when": "view == kusto.connections",
+          "group": "1_add@1"
+        },
+        {
+          "command": "kusto.addServerGroup",
+          "when": "view == kusto.connections",
+          "group": "1_add@2"
+        },
+        {
+          "command": "kusto.importConnectionsFromKustoExplorer",
+          "when": "view == kusto.connections",
+          "group": "1_add@3"
         },
         {
           "command": "kusto.newScratchPad",
           "when": "view == kusto.scratchPads",
           "group": "navigation@1"
+        },
+        {
+          "command": "kusto.importScratchPadsFromKustoExplorer",
+          "when": "view == kusto.scratchPads",
+          "group": "navigation@2"
+        },
+        {
+          "command": "kusto.newScratchPad",
+          "when": "view == kusto.scratchPads",
+          "group": "1_add@1"
+        },
+        {
+          "command": "kusto.importScratchPadsFromKustoExplorer",
+          "when": "view == kusto.scratchPads",
+          "group": "1_import@1"
         },
         {
           "command": "kusto.clearHistory",
@@ -333,6 +368,21 @@
           "command": "kusto.addServerToGroup",
           "when": "view == kusto.connections && viewItem == serverGroup",
           "group": "inline"
+        },
+        {
+          "command": "kusto.addServer",
+          "when": "view == kusto.connections && viewItem =~ /^(server|serverGroup|noConnection)$/",
+          "group": "1_add@1"
+        },
+        {
+          "command": "kusto.addServerGroup",
+          "when": "view == kusto.connections && viewItem =~ /^(server|serverGroup|noConnection)$/",
+          "group": "1_add@2"
+        },
+        {
+          "command": "kusto.addServerToGroup",
+          "when": "view == kusto.connections && viewItem == serverGroup",
+          "group": "1_add@3"
         },
         {
           "command": "kusto.removeServer",


### PR DESCRIPTION
import scratch pad query sets from Kusto Explorer recovery files
Add scratch pad terminology back into UI.
Scratch pad list is now ordered by user, not alphabetical. Add module descriptions to each file.