### PR TITLE
Add support for pivot charts

### DIFF
--- a/src/Client/features/chartEditorProvider.ts
+++ b/src/Client/features/chartEditorProvider.ts
@@ -44,6 +44,9 @@ const aspectRatios = ['16:9', '3:2', '4:3', '1:1', '3:4', '2:3', '9:16'];
 const textSizes = ['Extra Small', 'Small', 'Medium', 'Large', 'Extra Large'];
 const markerShapeOptions = ['circle', 'diamond', 'square', 'triangle-up', 'cross', 'star', 'x'];
 const tickAngles = [0, 15, 30, 45, 60, 75, 90, -15, -30, -45, -60, -75, -90];
+const aggregationTypes = ['Sum', 'Count', 'Average', 'Min', 'Max'];
+const maxSeriesOptions = [10, 20, 30, 40, 50];
+const maxPointsOptions = [100, 500, 1000, 5000, 10000, 50000];
 
 // ─── Interfaces ─────────────────────────────────────────────────────────────
 
@@ -349,6 +352,10 @@ class ChartEditorView implements IChartEditorView {
             if (seriesList) { var si = Array.from(seriesList.querySelectorAll('li span')).map(function(s) { return s.textContent; }); if (si.length) opts.seriesColumns = si; }
             var anomalyList = document.getElementById('opt-anomalyColumns-list');
             if (anomalyList) { var ai = Array.from(anomalyList.querySelectorAll('li span')).map(function(s) { return s.textContent; }); if (ai.length) opts.anomalyColumns = ai; }
+            var showMarkers = document.getElementById('opt-showMarkers');
+            if (showMarkers) opts.showMarkers = showMarkers.checked;
+            var markerOutline = document.getElementById('opt-markerOutline');
+            if (markerOutline) opts.markerOutline = markerOutline.checked;
             var markerShape = document.getElementById('opt-markerShape');
             if (markerShape && markerShape.value) opts.markerShape = markerShape.value;
             var cycleMarkerShapes = document.getElementById('opt-cycleMarkerShapes');
@@ -357,6 +364,14 @@ class ChartEditorView implements IChartEditorView {
             if (markerSize && markerSize.value) opts.markerSize = markerSize.value;
             var accumulate = document.getElementById('opt-accumulate');
             if (accumulate) opts.accumulate = accumulate.checked;
+            var binSize = document.getElementById('opt-binSize');
+            if (binSize && binSize.value) opts.binSize = binSize.value;
+            var aggregation = document.getElementById('opt-aggregation');
+            if (aggregation && aggregation.value) opts.aggregation = aggregation.value;
+            var maxSeries = document.getElementById('opt-maxSeries');
+            if (maxSeries && maxSeries.value) opts.maxSeries = Number(maxSeries.value);
+            var maxPointsPerSeries = document.getElementById('opt-maxPointsPerSeries');
+            if (maxPointsPerSeries && maxPointsPerSeries.value) opts.maxPointsPerSeries = Number(maxPointsPerSeries.value);
             var xAxis = document.getElementById('opt-xAxis');
             if (xAxis && xAxis.value) opts.xAxis = xAxis.value;
             var yAxis = document.getElementById('opt-yAxis');
@@ -507,11 +522,28 @@ class ChartEditorView implements IChartEditorView {
         const markerShapeOpts = ['', ...markerShapeOptions].map(s =>
             `<option value="${s}"${s === currentMarkerShape ? ' selected' : ''}>${s || '(default)'}</option>`
         ).join('');
+        const showMarkersChecked = opts.showMarkers === true ? ' checked' : '';
+        const markerOutlineChecked = opts.markerOutline === true ? ' checked' : '';
         const cycleMarkerShapesChecked = opts.cycleMarkerShapes === true ? ' checked' : '';
 
         const currentMarkerSize = opts.markerSize ?? '';
         const markerSizeOpts = ['', ...textSizes].map(s =>
             `<option value="${s}"${s === currentMarkerSize ? ' selected' : ''}>${s || '(default)'}</option>`
+        ).join('');
+
+        const currentAggregation = opts.aggregation ?? '';
+        const aggregationOpts = ['', ...aggregationTypes].map(a =>
+            `<option value="${a}"${a === currentAggregation ? ' selected' : ''}>${a || '(none)'}</option>`
+        ).join('');
+
+        const currentMaxSeries = opts.maxSeries ?? '';
+        const maxSeriesOpts = ['', ...maxSeriesOptions].map(n =>
+            `<option value="${n}"${String(n) === String(currentMaxSeries) ? ' selected' : ''}>${n || '(unlimited)'}</option>`
+        ).join('');
+
+        const currentMaxPoints = opts.maxPointsPerSeries ?? '';
+        const maxPointsOpts = ['', ...maxPointsOptions].map(n =>
+            `<option value="${n}"${String(n) === String(currentMaxPoints) ? ' selected' : ''}>${n || '(unlimited)'}</option>`
         ).join('');
 
         const currentXAxis = opts.xAxis ?? '';
@@ -558,7 +590,7 @@ class ChartEditorView implements IChartEditorView {
                     <select id="opt-legendPosition" onchange="_editorOnChartOptionChanged()">${legendPosOptions}</select>
                 </div>
                 <div class="field">
-                    <label for="opt-sort">Sort</label>
+                    <label for="opt-sort">Axis Order</label>
                     <select id="opt-sort" onchange="_editorOnChartOptionChanged()">${sortOptions}</select>
                 </div>
                 <div class="field">
@@ -606,6 +638,22 @@ class ChartEditorView implements IChartEditorView {
                     <input type="checkbox" id="opt-accumulate"${opts.accumulate ? ' checked' : ''} onchange="_editorOnChartOptionChanged()">
                     <label for="opt-accumulate">Accumulate</label>
                 </div>
+                <div class="field">
+                    <label for="opt-binSize">Bin Size</label>
+                    <input type="text" id="opt-binSize" value="${escapeHtml(opts.binSize ?? '')}" placeholder="e.g. 1h, 1d, 10" onchange="_editorOnChartOptionChanged()">
+                </div>
+                <div class="field">
+                    <label for="opt-aggregation">Aggregation</label>
+                    <select id="opt-aggregation" onchange="_editorOnChartOptionChanged()">${aggregationOpts}</select>
+                </div>
+                <div class="field">
+                    <label for="opt-maxSeries">Max Series</label>
+                    <select id="opt-maxSeries" onchange="_editorOnChartOptionChanged()">${maxSeriesOpts}</select>
+                </div>
+                <div class="field">
+                    <label for="opt-maxPointsPerSeries">Max Points per Series</label>
+                    <select id="opt-maxPointsPerSeries" onchange="_editorOnChartOptionChanged()">${maxPointsOpts}</select>
+                </div>
             </div>
 
             <div class="section-header collapsed" onclick="_editorToggleSection(this)">
@@ -616,13 +664,21 @@ class ChartEditorView implements IChartEditorView {
                     <label for="opt-markerShape">Shape</label>
                     <select id="opt-markerShape" onchange="_editorOnChartOptionChanged()">${markerShapeOpts}</select>
                 </div>
+                <div class="field">
+                    <label for="opt-markerSize">Size</label>
+                    <select id="opt-markerSize" onchange="_editorOnChartOptionChanged()">${markerSizeOpts}</select>
+                </div>
                 <div class="field checkbox-field">
                     <input type="checkbox" id="opt-cycleMarkerShapes"${cycleMarkerShapesChecked} onchange="_editorOnChartOptionChanged()">
                     <label for="opt-cycleMarkerShapes">Cycle Shapes</label>
                 </div>
-                <div class="field">
-                    <label for="opt-markerSize">Size</label>
-                    <select id="opt-markerSize" onchange="_editorOnChartOptionChanged()">${markerSizeOpts}</select>
+                <div class="field checkbox-field">
+                    <input type="checkbox" id="opt-showMarkers"${showMarkersChecked} onchange="_editorOnChartOptionChanged()">
+                    <label for="opt-showMarkers">Show on Lines</label>
+                </div>
+                <div class="field checkbox-field">
+                    <input type="checkbox" id="opt-markerOutline"${markerOutlineChecked} onchange="_editorOnChartOptionChanged()">
+                    <label for="opt-markerOutline">Outline</label>
                 </div>
             </div>
 

--- a/src/Client/features/chartEditorProvider.ts
+++ b/src/Client/features/chartEditorProvider.ts
@@ -199,26 +199,6 @@ class ChartEditorView implements IChartEditorView {
             display: inline;
             margin-bottom: 0;
         }
-        .edit-panel .column-picker {
-            display: flex;
-            gap: 4px;
-        }
-        .edit-panel .column-picker select {
-            flex: 1;
-            min-width: 0;
-        }
-        .edit-panel .column-picker button {
-            padding: 2px 8px;
-            cursor: pointer;
-            background: var(--vscode-button-background, #0e639c);
-            color: var(--vscode-button-foreground, #fff);
-            border: none;
-            border-radius: 2px;
-            font-size: inherit;
-        }
-        .edit-panel .column-picker button:hover {
-            background: var(--vscode-button-hoverBackground, #1177bb);
-        }
         .edit-panel .column-list {
             list-style: none;
             padding: 0;
@@ -291,12 +271,27 @@ class ChartEditorView implements IChartEditorView {
             li.appendChild(removeBtn);
             list.appendChild(li);
             picker.selectedIndex = 0;
+            _editorUpdateColumnPlaceholder(picker, list);
             _editorOnChartOptionChanged();
         }
 
         function _editorRemoveColumnItem(btn) {
             var li = btn.closest('li');
-            if (li) { li.remove(); _editorOnChartOptionChanged(); }
+            if (li) {
+                var list = li.parentNode;
+                var pickerId = list.id.replace('-list', '-picker');
+                li.remove();
+                var picker = document.getElementById(pickerId);
+                if (picker) _editorUpdateColumnPlaceholder(picker, list);
+                _editorOnChartOptionChanged();
+            }
+        }
+
+        function _editorUpdateColumnPlaceholder(picker, list) {
+            var firstOpt = picker.options[0];
+            if (firstOpt) {
+                firstOpt.textContent = list.children.length > 0 ? '(add)' : '(auto)';
+            }
         }
 
         function _editorMoveColumnItem(btn, dir) {
@@ -486,9 +481,15 @@ class ChartEditorView implements IChartEditorView {
             `<option value="${escapeHtml(c)}"${c === (opts.xColumn ?? '') ? ' selected' : ''}>${c || '(auto)'}</option>`
         ).join('');
 
-        const allColOptions = `<option value="" disabled selected>Pick a column</option>` + columnNames.map(c =>
+        const colOptionsList = columnNames.map(c =>
             `<option value="${escapeHtml(c)}">${escapeHtml(c)}</option>`
         ).join('');
+        const makeColPickerOptions = (hasItems: boolean) =>
+            `<option value="" disabled selected>${hasItems ? '(add)' : '(auto)'}</option>` + colOptionsList;
+
+        const yColPickerOptions = makeColPickerOptions((opts.yColumns ?? []).length > 0);
+        const seriesColPickerOptions = makeColPickerOptions((opts.seriesColumns ?? []).length > 0);
+        const anomalyColPickerOptions = makeColPickerOptions((opts.anomalyColumns ?? []).length > 0);
 
         const yColumnsItems = (opts.yColumns ?? []).map(c =>
             `<li><span>${escapeHtml(c)}</span><button onclick="_editorMoveColumnItem(this,-1)" title="Move up">&uarr;</button><button onclick="_editorMoveColumnItem(this,1)" title="Move down">&darr;</button><button onclick="_editorRemoveColumnItem(this)" title="Remove">&times;</button></li>`
@@ -588,27 +589,18 @@ class ChartEditorView implements IChartEditorView {
                 </div>
                 <div class="field">
                     <label>Y Columns</label>
-                    <div class="column-picker">
-                        <select id="opt-yColumns-picker">${allColOptions}</select>
-                        <button onclick="_editorAddColumnItem('opt-yColumns-picker','opt-yColumns-list')">Add</button>
-                    </div>
                     <ul id="opt-yColumns-list" class="column-list">${yColumnsItems}</ul>
+                    <select id="opt-yColumns-picker" onchange="_editorAddColumnItem('opt-yColumns-picker','opt-yColumns-list')">${yColPickerOptions}</select>
                 </div>
                 <div class="field">
                     <label>Series Columns</label>
-                    <div class="column-picker">
-                        <select id="opt-seriesColumns-picker">${allColOptions}</select>
-                        <button onclick="_editorAddColumnItem('opt-seriesColumns-picker','opt-seriesColumns-list')">Add</button>
-                    </div>
                     <ul id="opt-seriesColumns-list" class="column-list">${seriesItems}</ul>
+                    <select id="opt-seriesColumns-picker" onchange="_editorAddColumnItem('opt-seriesColumns-picker','opt-seriesColumns-list')">${seriesColPickerOptions}</select>
                 </div>
                 <div class="field">
                     <label>Anomaly Columns</label>
-                    <div class="column-picker">
-                        <select id="opt-anomalyColumns-picker">${allColOptions}</select>
-                        <button onclick="_editorAddColumnItem('opt-anomalyColumns-picker','opt-anomalyColumns-list')">Add</button>
-                    </div>
                     <ul id="opt-anomalyColumns-list" class="column-list">${anomalyColumnsItems}</ul>
+                    <select id="opt-anomalyColumns-picker" onchange="_editorAddColumnItem('opt-anomalyColumns-picker','opt-anomalyColumns-list')">${anomalyColPickerOptions}</select>
                 </div>
                 <div class="field checkbox-field">
                     <input type="checkbox" id="opt-accumulate"${opts.accumulate ? ' checked' : ''} onchange="_editorOnChartOptionChanged()">

--- a/src/Client/features/chartEditorProvider.ts
+++ b/src/Client/features/chartEditorProvider.ts
@@ -25,7 +25,6 @@ const chartTypes: ReadonlyMap<string, string> = new Map([
     ['ladderchart', 'Time - Ladder'],
     ['linechart', 'Line'],
     ['piechart', 'Pie'],
-    ['pivotchart', 'Pivot'],
     ['plotly', 'Plotly'],
     ['sankey', 'Sankey'],
     ['scatterchart', 'Scatter'],
@@ -33,7 +32,6 @@ const chartTypes: ReadonlyMap<string, string> = new Map([
     ['3Dchart', '3D'],
     ['timechart', 'Time - Line'],
     ['anomalychart', 'Time - Line w/ Anomalies'],
-    ['timepivot', 'Time - Pivot'],
     ['treemap', 'Tree Map'],
 ]);
 

--- a/src/Client/features/plotlyChartProvider.ts
+++ b/src/Client/features/plotlyChartProvider.ts
@@ -1359,6 +1359,7 @@ export class PlotlyChartProvider implements IChartProvider {
                 builder = this.buildBarOrColumnChart(data, options);
                 break;
             case ChartType.LineChart:
+            case ChartType.PivotChart:
             case ChartType.TimeLineChart:
             case ChartType.TimeLineWithAnomalyChart:
                 builder = this.buildLineChart(data, options);
@@ -1390,6 +1391,7 @@ export class PlotlyChartProvider implements IChartProvider {
                 builder = this.buildSankeyChart(data, options);
                 break;
             case ChartType.TimeLadderChart:
+            case ChartType.TimePivot:
                 builder = this.buildLadderChart(data, options);
                 break;
             default:
@@ -1992,7 +1994,16 @@ export class PlotlyChartProvider implements IChartProvider {
         const xColumn = this.get2dXColumn(data, options);
         if (!xColumn) return undefined;
 
-        const yColumns = this.get2dYColumns(data, options, xColumn);
+        // Auto-infer series column when not explicitly specified
+        let effectiveOptions = options;
+        if (!options.seriesColumns || options.seriesColumns.length === 0) {
+            const inferredSeries = this.inferSeriesColumn(data, xColumn, options.anomalyColumns);
+            if (inferredSeries) {
+                effectiveOptions = { ...options, seriesColumns: [inferredSeries.column.name] };
+            }
+        }
+
+        const yColumns = this.get2dYColumns(data, effectiveOptions, xColumn);
 
         if (options.title) builder = builder.withTitle(options.title);
         if (options.xTitle) builder = builder.setXAxisTitle(options.xTitle);
@@ -2015,8 +2026,8 @@ export class PlotlyChartProvider implements IChartProvider {
         if (options.showLegend === false) builder = builder.hideLegend();
         builder = applyCommonOptions(builder, options);
 
-        // Resolve series columns
-        const seriesCols = (options.seriesColumns ?? [])
+        // Resolve series columns (may include auto-inferred)
+        const seriesCols = (effectiveOptions.seriesColumns ?? [])
             .map(name => getColumnRef(data, name))
             .filter((c): c is ColumnRef => c !== undefined);
 
@@ -2087,32 +2098,56 @@ export class PlotlyChartProvider implements IChartProvider {
         return groups;
     }
 
+    /**
+     * Infers a series column from the data when none is explicitly specified.
+     * Picks the first non-x, non-numeric, non-datetime column.
+     */
+    private inferSeriesColumn(data: ResultTable, xColumn: ColumnRef, anomalyColumns?: string[]): ColumnRef | undefined {
+        const anomalySet = new Set(anomalyColumns ?? []);
+        for (let i = 0; i < data.columns.length; i++) {
+            if (i === xColumn.index) continue;
+            const col = data.columns[i];
+            if (col && !isNumericType(col.type) && !isDateTimeType(col.type) && !anomalySet.has(col.name)) {
+                return getColumnRefByIndex(data, i);
+            }
+        }
+        return undefined;
+    }
+
     // ─── Data Column Helpers ────────────────────────────────────────────
 
     private get2dXColumn(data: ResultTable, options: ChartOptions): ColumnRef | undefined {
         if (options.xColumn) {
             return getColumnRef(data, options.xColumn);
         }
+        const anomalySet = new Set(options.anomalyColumns ?? []);
         // For time-based chart types, prefer a datetime column as x-axis that is not in yColumns
         if (isTimeChartType(options.type)) {
             for (let i = 0; i < data.columns.length; i++) {
                 const col = data.columns[i];
                 if (col && isDateTimeType(col.type)
+                    && !anomalySet.has(col.name)
                     && (!options.yColumns || !options.yColumns.includes(col.name))) {
                     return getColumnRefByIndex(data, i);
                 }
             }
         }
-        // otherwise, pick the first column that is not in yColumns
+        // otherwise, pick the first column that is not in yColumns or anomalyColumns
         if (options.yColumns) {
             for (let i = 0; i < data.columns.length; i++) {
                 const col = data.columns[i];
-                if (col && !options.yColumns.includes(col.name)) {
+                if (col && !options.yColumns.includes(col.name) && !anomalySet.has(col.name)) {
                     return getColumnRefByIndex(data, i);
                 }
             }
         }
-        // otherwise, pick the first column
+        // otherwise, pick the first non-anomaly column
+        for (let i = 0; i < data.columns.length; i++) {
+            const col = data.columns[i];
+            if (col && !anomalySet.has(col.name)) {
+                return getColumnRefByIndex(data, i);
+            }
+        }
         return getColumnRefByIndex(data, 0);
     }
 
@@ -2123,11 +2158,12 @@ export class PlotlyChartProvider implements IChartProvider {
                 .filter((c): c is ColumnRef => c !== undefined);
         }
         const seriesSet = new Set(options.seriesColumns ?? []);
+        const anomalySet = new Set(options.anomalyColumns ?? []);
         const result: ColumnRef[] = [];
         for (let i = 0; i < data.columns.length; i++) {
-            if (i !== xColumn.index && !seriesSet.has(data.columns[i]!.name)) {
+            if (i !== xColumn.index && !seriesSet.has(data.columns[i]!.name) && !anomalySet.has(data.columns[i]!.name)) {
                 const ref = getColumnRefByIndex(data, i);
-                if (ref) result.push(ref);
+                if (ref && isNumericType(ref.column.type)) result.push(ref);
             }
         }
         return result;

--- a/src/Client/features/plotlyChartProvider.ts
+++ b/src/Client/features/plotlyChartProvider.ts
@@ -101,6 +101,7 @@ interface PlotlyMarker {
     size?: number | undefined;
     opacity?: number | undefined;
     symbol?: string | undefined;
+    line?: { color?: string; width?: number } | undefined;
 }
 
 interface PlotlyLine {
@@ -292,6 +293,8 @@ interface ScatterTrace extends PlotlyTraceBase {
     groupnorm?: string | undefined;
     line?: PlotlyLine | undefined;
     marker?: PlotlyMarker | undefined;
+    text?: unknown[] | undefined;
+    textposition?: string | undefined;
 }
 
 interface PieTrace extends PlotlyTraceBase {
@@ -546,14 +549,29 @@ class PlotlyChartBuilder {
         name?: string,
         showMarkers = false,
         yAxisId?: string,
+        markerSymbol?: string,
+        markerSize?: number,
+        showValues = false,
+        markerOutline = false,
+        outlineColor = 'white',
     ): PlotlyChartBuilder {
+        const markerObj: PlotlyMarker | undefined = showMarkers
+            ? { symbol: markerSymbol, size: markerSize, line: markerOutline ? { color: outlineColor, width: 1.5 } : undefined }
+            : undefined;
+        let mode = PlotlyScatterModes.Lines as string;
+        if (showMarkers && showValues) mode = 'lines+markers+text';
+        else if (showMarkers) mode = PlotlyScatterModes.LinesAndMarkers;
+        else if (showValues) mode = 'lines+text';
         const trace: ScatterTrace = {
             type: 'scatter',
             x,
             y,
-            mode: showMarkers ? PlotlyScatterModes.LinesAndMarkers : PlotlyScatterModes.Lines,
+            mode,
             name,
             yaxis: yAxisId,
+            marker: markerObj,
+            text: showValues ? y.map(v => v as unknown) : undefined,
+            textposition: showValues ? 'top center' : undefined,
         };
         return this.addTrace(trace);
     }
@@ -565,16 +583,23 @@ class PlotlyChartBuilder {
         yAxisId?: string,
         markerSymbol?: string,
         markerSize?: number,
+        showValues = false,
+        markerOutline = false,
+        outlineColor = 'white',
     ): PlotlyChartBuilder {
         const hasMarker = markerSymbol != null || markerSize != null;
         const trace: ScatterTrace = {
             type: 'scatter',
             x,
             y,
-            mode: PlotlyScatterModes.Markers,
+            mode: showValues ? 'markers+text' : PlotlyScatterModes.Markers,
             name,
             yaxis: yAxisId,
-            marker: hasMarker ? { symbol: markerSymbol, size: markerSize } : undefined,
+            marker: hasMarker || markerOutline
+                ? { symbol: markerSymbol, size: markerSize, line: markerOutline ? { color: outlineColor, width: 1.5 } : undefined }
+                : undefined,
+            text: showValues ? y.map(v => v as unknown) : undefined,
+            textposition: showValues ? 'top center' : undefined,
         };
         return this.addTrace(trace);
     }
@@ -924,6 +949,128 @@ function isTimeChartType(type: string): boolean {
         || type === ChartType.TimeLineWithAnomalyChart
         || type === ChartType.TimeLadderChart
         || type === ChartType.TimePivot;
+}
+
+// ─── Timespan Parsing & Binning ─────────────────────────────────────────────
+
+/** Suffix → milliseconds multiplier for KQL timespan literals. */
+const timespanSuffixes: Record<string, number> = {
+    'nanosecond': 1e-6, 'nanoseconds': 1e-6,
+    'tick': 1e-4, 'ticks': 1e-4,
+    'microsecond': 1e-3, 'microseconds': 1e-3,
+    'ms': 1, 'millisecond': 1, 'milliseconds': 1,
+    's': 1000, 'sec': 1000, 'second': 1000, 'seconds': 1000,
+    'm': 60_000, 'min': 60_000, 'minute': 60_000, 'minutes': 60_000,
+    'h': 3_600_000, 'hr': 3_600_000, 'hrs': 3_600_000, 'hour': 3_600_000, 'hours': 3_600_000,
+    'd': 86_400_000, 'day': 86_400_000, 'days': 86_400_000,
+};
+
+/**
+ * Parses a bin size string into milliseconds.
+ * Accepts KQL timespan syntax (e.g. "1d", "5m", "1.5h") or plain numbers.
+ * Returns undefined if the string cannot be parsed.
+ */
+function parseBinSize(value: string): number | undefined {
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+
+    // Try KQL timespan: number + suffix
+    const match = /^(\d+(?:\.\d+)?)\s*(nanoseconds?|ticks?|microseconds?|milliseconds?|ms|seconds?|sec|minutes?|min|hours?|hrs?|hr|days?|[smhd])$/i.exec(trimmed);
+    if (match) {
+        const num = parseFloat(match[1]!);
+        const suffix = match[2]!.toLowerCase();
+        const multiplier = timespanSuffixes[suffix];
+        if (multiplier !== undefined && num > 0) return num * multiplier;
+    }
+
+    // Try plain number (for numeric bin width)
+    const num = parseFloat(trimmed);
+    if (!isNaN(num) && num > 0) return num;
+
+    return undefined;
+}
+
+/** Aggregation function type. */
+type AggregationType = 'Sum' | 'Count' | 'Average' | 'Min' | 'Max';
+
+/**
+ * Bins x-values and aggregates y-values within each bin.
+ * For datetime x-values, binSizeMs is in milliseconds.
+ * For numeric x-values, binSizeMs is the bin width.
+ */
+function binAndAggregate(
+    xValues: unknown[],
+    yValues: number[],
+    binSize: number,
+    aggregation: AggregationType,
+    isDateTime: boolean,
+): { x: unknown[]; y: number[] } {
+    const bins = new Map<string | number, number[]>();
+    const binKeys: (string | number)[] = [];
+
+    for (let i = 0; i < xValues.length; i++) {
+        const xVal = xValues[i];
+        const yVal = yValues[i];
+        if (xVal == null || yVal == null) continue;
+
+        let binKey: string | number;
+        if (isDateTime) {
+            const ms = new Date(String(xVal)).getTime();
+            if (isNaN(ms)) continue;
+            const binned = Math.floor(ms / binSize) * binSize;
+            binKey = new Date(binned).toISOString();
+        } else {
+            const num = typeof xVal === 'number' ? xVal : parseFloat(String(xVal));
+            if (isNaN(num)) continue;
+            binKey = Math.floor(num / binSize) * binSize;
+        }
+
+        let group = bins.get(binKey);
+        if (!group) {
+            group = [];
+            bins.set(binKey, group);
+            binKeys.push(binKey);
+        }
+        group.push(yVal);
+    }
+
+    const resultX: unknown[] = [];
+    const resultY: number[] = [];
+
+    for (const key of binKeys) {
+        const values = bins.get(key)!;
+        resultX.push(key);
+        resultY.push(aggregateValues(values, aggregation));
+    }
+
+    return { x: resultX, y: resultY };
+}
+
+function aggregateValues(values: number[], aggregation: AggregationType): number {
+    switch (aggregation) {
+        case 'Sum': return values.reduce((a, b) => a + b, 0);
+        case 'Count': return values.length;
+        case 'Average': return values.reduce((a, b) => a + b, 0) / values.length;
+        case 'Min': return Math.min(...values);
+        case 'Max': return Math.max(...values);
+    }
+}
+
+/**
+ * Downsamples x/y arrays to at most maxPoints by taking every Nth point.
+ * Always includes the first and last points to preserve the range.
+ */
+function downsample(x: unknown[], y: number[], maxPoints: number): { x: unknown[]; y: number[] } {
+    if (x.length <= maxPoints) return { x, y };
+    const step = (x.length - 1) / (maxPoints - 1);
+    const resultX: unknown[] = [];
+    const resultY: number[] = [];
+    for (let i = 0; i < maxPoints; i++) {
+        const idx = Math.round(i * step);
+        resultX.push(x[idx]!);
+        resultY.push(y[idx]!);
+    }
+    return { x: resultX, y: resultY };
 }
 
 /** Ordered set of marker shapes for cycling. */
@@ -1362,10 +1509,10 @@ export class PlotlyChartProvider implements IChartProvider {
             case ChartType.PivotChart:
             case ChartType.TimeLineChart:
             case ChartType.TimeLineWithAnomalyChart:
-                builder = this.buildLineChart(data, options);
+                builder = this.buildLineChart(data, options, darkMode);
                 break;
             case ChartType.ScatterChart:
-                builder = this.buildScatterChart(data, options);
+                builder = this.buildScatterChart(data, options, darkMode);
                 break;
             case ChartType.PieChart:
                 builder = this.buildPieChart(data, options);
@@ -1496,7 +1643,7 @@ export class PlotlyChartProvider implements IChartProvider {
 
     // ─── Line / Scatter / Area ──────────────────────────────────────────
 
-    private buildLineChart(data: ResultTable, options: ChartOptions): PlotlyChartBuilder | undefined {
+    private buildLineChart(data: ResultTable, options: ChartOptions, darkMode = false): PlotlyChartBuilder | undefined {
         const anomalySet = new Set(options.anomalyColumns ?? []);
 
         // If anomalyColumns are specified, exclude them from y-columns so they don't render as lines
@@ -1510,8 +1657,12 @@ export class PlotlyChartProvider implements IChartProvider {
             })()
             : options;
 
+        const hasMarkers = options.showMarkers === true;
+        const showValues = options.showValues === true;
+        const markerOutline = options.markerOutline === true;
+        const outlineColor = darkMode ? 'white' : '#333';
         let builder = this.build2dChart(new PlotlyChartBuilder(), data, effectiveOptions,
-            (b, x, y, name, yAxis) => b.add2DLineTrace(x, y, name, false, yAxis));
+            (b, x, y, name, yAxis, traceIndex) => b.add2DLineTrace(x, y, name, hasMarkers, yAxis, getMarkerShape(options, traceIndex), getMarkerSize(options), showValues, markerOutline, outlineColor));
 
         // Overlay anomaly scatter points if anomalyColumns are present
         if (builder && anomalySet.size > 0) {
@@ -1554,9 +1705,10 @@ export class PlotlyChartProvider implements IChartProvider {
         return builder;
     }
 
-    private buildScatterChart(data: ResultTable, options: ChartOptions): PlotlyChartBuilder | undefined {
+    private buildScatterChart(data: ResultTable, options: ChartOptions, darkMode = false): PlotlyChartBuilder | undefined {
+        const outlineColor = darkMode ? 'white' : '#333';
         return this.build2dChart(new PlotlyChartBuilder(), data, options,
-            (b, x, y, name, yAxis, traceIndex) => b.add2DScatterTrace(x, y, name, yAxis, getMarkerShape(options, traceIndex), getMarkerSize(options)));
+            (b, x, y, name, yAxis, traceIndex) => b.add2DScatterTrace(x, y, name, yAxis, getMarkerShape(options, traceIndex), getMarkerSize(options), options.showValues === true, options.markerOutline === true, outlineColor));
     }
 
     private buildAreaChart(data: ResultTable, options: ChartOptions): PlotlyChartBuilder | undefined {
@@ -2031,16 +2183,42 @@ export class PlotlyChartProvider implements IChartProvider {
             .map(name => getColumnRef(data, name))
             .filter((c): c is ColumnRef => c !== undefined);
 
+        // Resolve binning options
+        const binSize = options.binSize ? parseBinSize(options.binSize) : undefined;
+        const aggregation = options.aggregation as AggregationType | undefined;
+        const shouldBin = binSize !== undefined && binSize > 0 && aggregation !== undefined;
+        const xIsDateTime = isDateTimeType(xColumn.column.type);
+
         if (seriesCols.length > 0) {
             // Pivot data by series column values
-            const groups = this.groupRowsBySeries(data, seriesCols);
+            let groups = this.groupRowsBySeries(data, seriesCols);
+
+            // Limit to top N series by total y-value
+            if (options.maxSeries != null && options.maxSeries > 0 && groups.size > options.maxSeries) {
+                const ranked = [...groups.entries()].map(([key, rowIndices]) => {
+                    let total = 0;
+                    for (const ri of rowIndices) {
+                        const row = data.rows[ri];
+                        if (!row) continue;
+                        for (const yCol of yColumns) {
+                            if (!isNumericType(yCol.column.type)) continue;
+                            const v = row[yCol.index];
+                            if (v != null) total += Math.abs(toNumber(v));
+                        }
+                    }
+                    return { key, rowIndices, total };
+                });
+                ranked.sort((a, b) => b.total - a.total);
+                groups = new Map(ranked.slice(0, options.maxSeries).map(r => [r.key, r.rowIndices]));
+            }
+
             const multipleYCols = yColumns.length > 1;
             let traceIndex = 0;
             for (const [seriesKey, rowIndices] of groups) {
                 for (const yCol of yColumns) {
                     if (!isNumericType(yCol.column.type)) continue;
-                    const xValues: unknown[] = [];
-                    const yValues: number[] = [];
+                    let xValues: unknown[] = [];
+                    let yValues: number[] = [];
                     for (const ri of rowIndices) {
                         const row = data.rows[ri];
                         if (!row) continue;
@@ -2051,12 +2229,23 @@ export class PlotlyChartProvider implements IChartProvider {
                             yValues.push(sanitizeDouble(toNumber(yVal)));
                         }
                     }
+                    if (shouldBin && xValues.length > 0) {
+                        const binned = binAndAggregate(xValues, yValues, binSize, aggregation, xIsDateTime);
+                        xValues = binned.x;
+                        yValues = binned.y;
+                    }
                     if (xValues.length > 0) {
                         // Sort by x-value so lines don't zigzag
                         const indices = xValues.map((_, i) => i);
                         indices.sort((a, b) => (xValues[a]! < xValues[b]! ? -1 : xValues[a]! > xValues[b]! ? 1 : 0));
-                        const sortedX = indices.map(i => xValues[i]!);
-                        const sortedY = indices.map(i => yValues[i]!);
+                        let sortedX: unknown[] = indices.map(i => xValues[i]!);
+                        let sortedY: number[] = indices.map(i => yValues[i]!);
+                        // Downsample if over max points
+                        if (options.maxPointsPerSeries != null && options.maxPointsPerSeries > 0) {
+                            const ds = downsample(sortedX, sortedY, options.maxPointsPerSeries);
+                            sortedX = ds.x;
+                            sortedY = ds.y;
+                        }
                         const traceName = multipleYCols ? `${seriesKey} - ${yCol.column.name}` : seriesKey;
                         builder = addTrace(builder, sortedX, sortedY, traceName, undefined, traceIndex);
                         traceIndex++;
@@ -2067,8 +2256,18 @@ export class PlotlyChartProvider implements IChartProvider {
             // No series columns: one trace per y-column (existing behavior)
             let traceIndex = 0;
             for (const valueColumn of yColumns) {
-                const result = this.get2DChartData(data, xColumn, valueColumn);
+                let result = this.get2DChartData(data, xColumn, valueColumn);
                 if (result) {
+                    if (shouldBin) {
+                        result = binAndAggregate(result.x, result.y, binSize, aggregation, xIsDateTime);
+                    }
+                    // Sort by x-value so lines don't zigzag
+                    const indices = result.x.map((_, i) => i);
+                    indices.sort((a, b) => (result!.x[a]! < result!.x[b]! ? -1 : result!.x[a]! > result!.x[b]! ? 1 : 0));
+                    result = { x: indices.map(i => result!.x[i]!), y: indices.map(i => result!.y[i]!) };
+                    if (options.maxPointsPerSeries != null && options.maxPointsPerSeries > 0) {
+                        result = downsample(result.x, result.y, options.maxPointsPerSeries);
+                    }
                     builder = addTrace(builder, result.x, result.y, valueColumn.column.name, undefined, traceIndex);
                     traceIndex++;
                 }

--- a/src/Client/features/resultsViewer.ts
+++ b/src/Client/features/resultsViewer.ts
@@ -115,6 +115,12 @@ function getChartDefaults(): Partial<server.ChartOptions> {
     if (xTickAngle) { defaults.xTickAngle = Number(xTickAngle); }
     const yTickAngle = config.get<string>('yTickAngle');
     if (yTickAngle) { defaults.yTickAngle = Number(yTickAngle); }
+    const showMarkers = config.get<string>('showMarkers');
+    if (showMarkers === 'yes') { defaults.showMarkers = true; }
+    else if (showMarkers === 'no') { defaults.showMarkers = false; }
+    const markerOutline = config.get<string>('markerOutline');
+    if (markerOutline === 'yes') { defaults.markerOutline = true; }
+    else if (markerOutline === 'no') { defaults.markerOutline = false; }
     const markerShape = config.get<string>('markerShape');
     if (markerShape) { defaults.markerShape = markerShape; }
     const cycleMarkerShapes = config.get<string>('markerShapesCycle');

--- a/src/Client/features/server.ts
+++ b/src/Client/features/server.ts
@@ -589,9 +589,15 @@ export interface ChartOptions {
     mode?: string;
     aspectRatio?: string;
     textSize?: string;
+    showMarkers?: boolean;
+    markerOutline?: boolean;
     markerShape?: string;
     cycleMarkerShapes?: boolean;
     markerSize?: string;
+    binSize?: string;
+    aggregation?: string;
+    maxSeries?: number;
+    maxPointsPerSeries?: number;
 }
 
 /** Position in a document. */

--- a/src/Client/package.json
+++ b/src/Client/package.json
@@ -870,6 +870,13 @@
             "default": "",
             "description": "Default Y-axis tick label angle for charts"
           },
+          "kusto.chart.showMarkers": {
+            "type": "string",
+            "enum": ["", "yes", "no"],
+            "enumItemLabels": ["(default)", "Yes", "No"],
+            "default": "",
+            "description": "Show markers on line chart traces by default"
+          },
           "kusto.chart.markerShape": {
             "type": "string",
             "enum": [
@@ -901,6 +908,13 @@
             "enumItemLabels": ["(default)", "Yes", "No"],
             "default": "",
             "description": "Marker Shapes Cycle: cycle through shapes across traces by default"
+          },
+          "kusto.chart.markerOutline": {
+            "type": "string",
+            "enum": ["", "yes", "no"],
+            "enumItemLabels": ["(default)", "Yes", "No"],
+            "default": "",
+            "description": "Show a white outline around markers to help them stand out"
           },
           "kusto.chart.markerSize": {
             "type": "string",

--- a/src/Client/tests/unit/plotlyChartProvider.test.ts
+++ b/src/Client/tests/unit/plotlyChartProvider.test.ts
@@ -929,6 +929,144 @@ describe('PlotlyChartProvider', () => {
             });
         });
 
+        // ─── Auto-inference ─────────────────────────────────────────────
+
+        describe('auto-inference', () => {
+            it('infers series column from first non-x string column when seriesColumns is not set', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'region', type: 'string' },
+                        { name: 'count', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01', 'East', 10],
+                        ['2024-01-01', 'West', 20],
+                        ['2024-01-02', 'East', 15],
+                        ['2024-01-02', 'West', 25],
+                    ],
+                );
+                const html = renderAndGetHtml(table, { type: 'timechart' });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                expect(traces.length).toBe(2);
+                expect((traces[0] as Record<string, unknown>).name).toBe('East');
+                expect((traces[1] as Record<string, unknown>).name).toBe('West');
+            });
+
+            it('does not infer series column when all non-x columns are numeric', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'sales', type: 'int' },
+                        { name: 'profit', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01', 10, 2],
+                        ['2024-01-02', 15, 3],
+                    ],
+                );
+                const html = renderAndGetHtml(table, { type: 'timechart' });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                // One trace per numeric column, no series pivoting
+                expect(traces.length).toBe(2);
+                expect((traces[0] as Record<string, unknown>).name).toBe('sales');
+                expect((traces[1] as Record<string, unknown>).name).toBe('profit');
+            });
+
+            it('infers series for non-time chart types', () => {
+                const table = makeTable(
+                    [
+                        { name: 'category', type: 'string' },
+                        { name: 'region', type: 'string' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['A', 'East', 10],
+                        ['A', 'West', 20],
+                        ['B', 'East', 30],
+                        ['B', 'West', 40],
+                    ],
+                );
+                // x=category (first col), inferred series=region, y=value
+                const html = renderAndGetHtml(table, { type: 'columnchart' });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                expect(traces.length).toBe(2);
+                expect((traces[0] as Record<string, unknown>).name).toBe('East');
+                expect((traces[1] as Record<string, unknown>).name).toBe('West');
+            });
+
+            it('does not override explicitly set seriesColumns', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'region', type: 'string' },
+                        { name: 'product', type: 'string' },
+                        { name: 'count', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01', 'East', 'Widget', 10],
+                        ['2024-01-01', 'West', 'Gadget', 20],
+                    ],
+                );
+                // Explicitly set product as series, not region
+                const html = renderAndGetHtml(table, {
+                    type: 'linechart',
+                    seriesColumns: ['product'],
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                expect(traces.length).toBe(2);
+                expect((traces[0] as Record<string, unknown>).name).toBe('Widget');
+                expect((traces[1] as Record<string, unknown>).name).toBe('Gadget');
+            });
+
+            it('renders pivotchart as linechart with auto-inferred series', () => {
+                const table = makeTable(
+                    [
+                        { name: 'category', type: 'string' },
+                        { name: 'region', type: 'string' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['A', 'East', 10],
+                        ['A', 'West', 20],
+                        ['B', 'East', 30],
+                    ],
+                );
+                const html = renderAndGetHtml(table, { type: 'pivotchart' });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                expect(traces.length).toBe(2);
+                expect((traces[0] as Record<string, unknown>).name).toBe('East');
+                expect((traces[1] as Record<string, unknown>).name).toBe('West');
+                // Should render as line traces (scatter with mode lines)
+                expect((traces[0] as Record<string, unknown>).mode).toBe('lines');
+            });
+
+            it('renders timepivot as ladder chart', () => {
+                const table = makeTable(
+                    [
+                        { name: 'start', type: 'datetime' },
+                        { name: 'end', type: 'datetime' },
+                        { name: 'task', type: 'string' },
+                    ],
+                    [
+                        ['2024-01-01', '2024-01-05', 'Task A'],
+                        ['2024-01-03', '2024-01-07', 'Task B'],
+                    ],
+                );
+                const html = renderAndGetHtml(table, { type: 'timepivot' });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                expect(traces.length).toBeGreaterThan(0);
+                // Ladder chart uses horizontal bars
+                expect((traces[0] as Record<string, unknown>).orientation).toBe('h');
+            });
+        });
+
         // ─── Chart options ──────────────────────────────────────────────
 
         describe('chart options', () => {

--- a/src/Client/tests/unit/plotlyChartProvider.test.ts
+++ b/src/Client/tests/unit/plotlyChartProvider.test.ts
@@ -1067,6 +1067,362 @@ describe('PlotlyChartProvider', () => {
             });
         });
 
+        // ─── Binning & Aggregation ──────────────────────────────────────
+
+        describe('binning and aggregation', () => {
+            it('bins datetime x-values by day and sums y-values', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01T10:00:00Z', 5],
+                        ['2024-01-01T14:00:00Z', 3],
+                        ['2024-01-02T08:00:00Z', 10],
+                        ['2024-01-02T20:00:00Z', 2],
+                    ],
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'timechart',
+                    binSize: '1d',
+                    aggregation: 'Sum',
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                expect(traces.length).toBe(1);
+                const trace = traces[0] as Record<string, unknown>;
+                expect((trace.y as number[]).length).toBe(2);
+                expect((trace.y as number[])[0]).toBe(8);  // 5 + 3
+                expect((trace.y as number[])[1]).toBe(12); // 10 + 2
+            });
+
+            it('bins datetime x-values by hour and counts', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01T10:05:00Z', 1],
+                        ['2024-01-01T10:30:00Z', 2],
+                        ['2024-01-01T10:59:00Z', 3],
+                        ['2024-01-01T11:15:00Z', 4],
+                    ],
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'timechart',
+                    binSize: '1h',
+                    aggregation: 'Count',
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                const trace = traces[0] as Record<string, unknown>;
+                expect((trace.y as number[])[0]).toBe(3); // 3 values in 10:xx
+                expect((trace.y as number[])[1]).toBe(1); // 1 value in 11:xx
+            });
+
+            it('bins with average aggregation', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01T00:00:00Z', 10],
+                        ['2024-01-01T12:00:00Z', 20],
+                        ['2024-01-02T00:00:00Z', 30],
+                    ],
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'timechart',
+                    binSize: '1d',
+                    aggregation: 'Average',
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                const trace = traces[0] as Record<string, unknown>;
+                expect((trace.y as number[])[0]).toBe(15); // (10+20)/2
+                expect((trace.y as number[])[1]).toBe(30);
+            });
+
+            it('bins numeric x-values by width', () => {
+                const table = makeTable(
+                    [
+                        { name: 'x', type: 'real' },
+                        { name: 'y', type: 'int' },
+                    ],
+                    [
+                        [1.5, 10],
+                        [3.2, 20],
+                        [7.8, 15],
+                        [8.1, 5],
+                    ],
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'linechart',
+                    binSize: '5',
+                    aggregation: 'Sum',
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                const trace = traces[0] as Record<string, unknown>;
+                // bin 0: 1.5, 3.2 → sum 30
+                // bin 5: 7.8, 8.1 → sum 20
+                expect((trace.x as number[])).toEqual([0, 5]);
+                expect((trace.y as number[])).toEqual([30, 20]);
+            });
+
+            it('applies binning with series columns', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'region', type: 'string' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01T10:00:00Z', 'East', 5],
+                        ['2024-01-01T14:00:00Z', 'East', 3],
+                        ['2024-01-01T10:00:00Z', 'West', 10],
+                        ['2024-01-01T14:00:00Z', 'West', 20],
+                    ],
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'timechart',
+                    seriesColumns: ['region'],
+                    binSize: '1d',
+                    aggregation: 'Sum',
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                expect(traces.length).toBe(2);
+                const east = traces[0] as Record<string, unknown>;
+                expect(east.name).toBe('East');
+                expect((east.y as number[])[0]).toBe(8); // 5 + 3
+                const west = traces[1] as Record<string, unknown>;
+                expect(west.name).toBe('West');
+                expect((west.y as number[])[0]).toBe(30); // 10 + 20
+            });
+
+            it('does not bin when binSize is not set', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01T10:00:00Z', 5],
+                        ['2024-01-01T14:00:00Z', 3],
+                    ],
+                );
+                const html = renderAndGetHtml(table, { type: 'timechart' });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                const trace = traces[0] as Record<string, unknown>;
+                expect((trace.y as number[]).length).toBe(2); // no aggregation
+            });
+
+            it('parses various KQL timespan suffixes', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01T00:00:00Z', 1],
+                        ['2024-01-01T00:00:30Z', 2],
+                        ['2024-01-01T00:01:00Z', 3],
+                        ['2024-01-01T00:01:30Z', 4],
+                    ],
+                );
+                // Bin by 1 minute
+                const html = renderAndGetHtml(table, {
+                    type: 'timechart',
+                    binSize: '1minute',
+                    aggregation: 'Sum',
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                const trace = traces[0] as Record<string, unknown>;
+                expect((trace.y as number[])[0]).toBe(3);  // 1 + 2
+                expect((trace.y as number[])[1]).toBe(7);  // 3 + 4
+            });
+
+            it('supports min aggregation', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01T00:00:00Z', 10],
+                        ['2024-01-01T12:00:00Z', 20],
+                        ['2024-01-01T18:00:00Z', 5],
+                    ],
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'timechart',
+                    binSize: '1d',
+                    aggregation: 'Min',
+                });
+                expect(html).toBeDefined();
+                const trace = parseTraces(html!)[0] as Record<string, unknown>;
+                expect((trace.y as number[])[0]).toBe(5);
+            });
+
+            it('supports max aggregation', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01T00:00:00Z', 10],
+                        ['2024-01-01T12:00:00Z', 20],
+                        ['2024-01-01T18:00:00Z', 5],
+                    ],
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'timechart',
+                    binSize: '1d',
+                    aggregation: 'Max',
+                });
+                expect(html).toBeDefined();
+                const trace = parseTraces(html!)[0] as Record<string, unknown>;
+                expect((trace.y as number[])[0]).toBe(20);
+            });
+        });
+
+        // ─── Max Series & Max Points ────────────────────────────────────
+
+        describe('max series', () => {
+            it('limits to top N series by total y-value', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'region', type: 'string' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01', 'Small', 1],
+                        ['2024-01-01', 'Big', 100],
+                        ['2024-01-01', 'Medium', 50],
+                        ['2024-01-02', 'Small', 2],
+                        ['2024-01-02', 'Big', 200],
+                        ['2024-01-02', 'Medium', 60],
+                    ],
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'timechart',
+                    seriesColumns: ['region'],
+                    maxSeries: 2,
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                expect(traces.length).toBe(2);
+                const names = traces.map(t => (t as Record<string, unknown>).name);
+                expect(names).toContain('Big');
+                expect(names).toContain('Medium');
+                expect(names).not.toContain('Small');
+            });
+
+            it('does not limit when maxSeries is not set', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'region', type: 'string' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01', 'A', 1],
+                        ['2024-01-01', 'B', 2],
+                        ['2024-01-01', 'C', 3],
+                    ],
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'timechart',
+                    seriesColumns: ['region'],
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                expect(traces.length).toBe(3);
+            });
+        });
+
+        describe('max points per series', () => {
+            it('downsamples traces that exceed the limit', () => {
+                const rows: unknown[][] = [];
+                for (let i = 0; i < 100; i++) {
+                    rows.push([`2024-01-01T${String(Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00Z`, i]);
+                }
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    rows,
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'timechart',
+                    maxPointsPerSeries: 10,
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                const trace = traces[0] as Record<string, unknown>;
+                expect((trace.x as unknown[]).length).toBe(10);
+                expect((trace.y as number[]).length).toBe(10);
+            });
+
+            it('does not downsample when under the limit', () => {
+                const table = makeTable(
+                    [
+                        { name: 'timestamp', type: 'datetime' },
+                        { name: 'value', type: 'int' },
+                    ],
+                    [
+                        ['2024-01-01', 10],
+                        ['2024-01-02', 20],
+                        ['2024-01-03', 30],
+                    ],
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'timechart',
+                    maxPointsPerSeries: 100,
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                const trace = traces[0] as Record<string, unknown>;
+                expect((trace.x as unknown[]).length).toBe(3);
+            });
+
+            it('preserves first and last points when downsampling', () => {
+                const rows: unknown[][] = [];
+                for (let i = 0; i < 50; i++) {
+                    rows.push([i, i * 10]);
+                }
+                const table = makeTable(
+                    [
+                        { name: 'x', type: 'int' },
+                        { name: 'y', type: 'int' },
+                    ],
+                    rows,
+                );
+                const html = renderAndGetHtml(table, {
+                    type: 'linechart',
+                    xColumn: 'x',
+                    yColumns: ['y'],
+                    maxPointsPerSeries: 5,
+                });
+                expect(html).toBeDefined();
+                const traces = parseTraces(html!);
+                const trace = traces[0] as Record<string, unknown>;
+                const xVals = trace.x as number[];
+                expect(xVals.length).toBe(5);
+                expect(xVals[0]).toBe(0);             // first point
+                expect(xVals[xVals.length - 1]).toBe(49); // last point
+            });
+        });
+
         // ─── Chart options ──────────────────────────────────────────────
 
         describe('chart options', () => {


### PR DESCRIPTION
Add pivot charts as mapping to normal charts but supplying the data transform logic in the chart editor.
Add timepivot currently as mapping to ladderchart (which is very similar)