### PR TITLE
Change extension display name to not conflict in marketplace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
   package-vsix:
     name: Build VSIX Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [unit-test-server, unit-test-client, integration-test-client]
     permissions:
       contents: write

--- a/src/Client/package.json
+++ b/src/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kusto-explorer-vscode",
-  "displayName": "Kusto Explorer",
+  "displayName": "Microsoft Kusto Explorer",
   "description": "Edit, run and chart Kusto queries (KQL).",
   "version": "0.2.0",
   "publisher": "ms-kusto",


### PR DESCRIPTION
The extension display name of "Kusto Explorer" matches an older extension that has been renamed, but marketplace will not let use it now for a different publisher.  Changing it to "Microsoft Kusto Explorer" as a work around.