### PR TITLE
Show graph snapshots in the connection pane

### DIFF
--- a/src/Client/features/connectionsPanel.ts
+++ b/src/Client/features/connectionsPanel.ts
@@ -685,7 +685,8 @@ type KustoTreeItem =
 | FunctionTreeItem
 | EntityGroupTreeItem
 | EntityGroupMemberTreeItem
-| GraphModelTreeItem;
+| GraphModelTreeItem
+| GraphSnapshotTreeItem;
 
 class NoConnectionTreeItem extends vscode.TreeItem {
     constructor() {
@@ -937,10 +938,25 @@ class GraphModelTreeItem extends vscode.TreeItem {
         public readonly databaseName: string,
         public readonly graphInfo: DatabaseGraphModelInfo
     ) {
-        super(graphInfo.name, vscode.TreeItemCollapsibleState.None);
+        const hasSnapshots = (graphInfo.snapshots?.length ?? 0) > 0;
+        super(graphInfo.name, hasSnapshots ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None);
         this.id = `graphModel:${clusterName}:${databaseName}:${graphInfo.name}`;
         this.contextValue = 'graphModel';
         this.iconPath = new vscode.ThemeIcon('type-hierarchy');
+    }
+}
+
+class GraphSnapshotTreeItem extends vscode.TreeItem {
+    constructor(
+        public readonly clusterName: string,
+        public readonly databaseName: string,
+        public readonly modelName: string,
+        public readonly snapshotName: string
+    ) {
+        super(snapshotName, vscode.TreeItemCollapsibleState.None);
+        this.id = `graphSnapshot:${clusterName}:${databaseName}:${modelName}:${snapshotName}`;
+        this.contextValue = 'graphSnapshot';
+        this.iconPath = new vscode.ThemeIcon('history');
     }
 }
 
@@ -1402,6 +1418,12 @@ class KustoConnectionsProvider implements vscode.TreeDataProvider<KustoTreeItem>
                 .map(e => new EntityGroupMemberTreeItem(element.clusterName, element.databaseName, element.groupInfo.name, e));
         }
 
+        if (element instanceof GraphModelTreeItem) {
+            return (element.graphInfo.snapshots ?? [])
+                .map(s => new GraphSnapshotTreeItem(element.clusterName, element.databaseName, element.graphInfo.name, s))
+                .sort((a, b) => a.snapshotName.localeCompare(b.snapshotName, undefined, { sensitivity: 'base' }));
+        }
+
         return [];
     }
 
@@ -1459,6 +1481,15 @@ class KustoConnectionsProvider implements vscode.TreeDataProvider<KustoTreeItem>
         if (element instanceof GraphModelTreeItem)
         {
             return new DatabaseFolderTreeItem(element.clusterName, element.databaseName, 'graphModels', 'Graph Models', 'type-hierarchy');
+        }
+        if (element instanceof GraphSnapshotTreeItem)
+        {
+            const dbInfo = this.connections.getDatabaseInfo(element.clusterName, element.databaseName);
+            const graphInfo = dbInfo?.graphModels?.find(g => g.name === element.modelName);
+            if (graphInfo) {
+                return new GraphModelTreeItem(element.clusterName, element.databaseName, graphInfo);
+            }
+            return undefined;
         }
         if (element instanceof EntityFolderTreeItem)
         {


### PR DESCRIPTION
### Problem
The server-side graph model/snapshot schema fix is now on main, but the Connections tree still renders graph models as leaf nodes. As a result, snapshot names are present in DatabaseGraphModelInfo.snapshots but cannot be seen in the UI.

### Approach
- Make GraphModelTreeItem collapsible when graphInfo.snapshots has entries.
- Add a GraphSnapshotTreeItem child node with the history icon.
- Add getChildren / getParent wiring so snapshots appear under their graph model and reveal/navigation works consistently with other entity-member nodes.

This PR intentionally leaves graph model discovery and snapshot schema loading to the maintainer fix already merged in #98.

### Validation
- 
pm run compile
- 
pm run lint
- 
pm test (448/448 tests pass)
- Manual check: graph models show their snapshots under the model in the Connections tree.