### PR TITLE
Add nuget.config with nuget.org package source

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Problem
Building the server project (\src/Server\) fails on machines where nuget.org is not configured as a machine-level NuGet package source, since packages like \Microsoft.Azure.Kusto.Data\ and \StreamJsonRpc\ cannot be found.

## Solution
Add a repo-level \
uget.config\ that explicitly configures nuget.org as the package source. Uses \<clear />\ to ensure a clean, predictable set of sources regardless of machine configuration.

## Validation
- Reverted machine-level nuget.org source to confirm the repo-level config is sufficient
- Verified \dotnet restore\ and \dotnet build\ succeed using only the repo-level config