### PR TITLE
Add VS Code debug profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,6 +403,7 @@ MigrationBackup/
 FodyWeavers.xsd
 
 # VS Code files for those working on multiple tools
+!.vscode/
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,10 +7,10 @@
       "request": "launch",
       "preLaunchTask": "Build Extension Debug",
       "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}\\src\\Client"
+        "--extensionDevelopmentPath=${workspaceFolder}/src/Client"
       ],
       "outFiles": [
-        "${workspaceFolder}\\src\\Client\\dist\\**\\*.js"
+        "${workspaceFolder}/src/Client/dist/**/*.js"
       ]
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "preLaunchTask": "Build Extension Debug",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}\\src\\Client"
+      ],
+      "outFiles": [
+        "${workspaceFolder}\\src\\Client\\dist\\**\\*.js"
+      ]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build Client",
+      "type": "shell",
+      "command": "npm run compile",
+      "options": {
+        "cwd": "${workspaceFolder}\\src\\Client"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Build Debug Server",
+      "type": "shell",
+      "command": "npm run build-debug-server",
+      "options": {
+        "cwd": "${workspaceFolder}\\src\\Client"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Build Extension Debug",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "Build Client",
+        "Build Debug Server"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
       "type": "shell",
       "command": "npm run compile",
       "options": {
-        "cwd": "${workspaceFolder}\\src\\Client"
+        "cwd": "${workspaceFolder}/src/Client"
       },
       "problemMatcher": []
     },
@@ -15,7 +15,7 @@
       "type": "shell",
       "command": "npm run build-debug-server",
       "options": {
-        "cwd": "${workspaceFolder}\\src\\Client"
+        "cwd": "${workspaceFolder}/src/Client"
       },
       "problemMatcher": "$msCompile"
     },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,17 +124,17 @@ npm run compile
 ### Running Locally
 
 1. Open the repository in VS Code
-2. Press `F5` to launch the Extension Development Host
-3. Open a `.kql` file to activate the extension
+2. Select the **Run Extension** debug profile
+3. Press `F5` to build the client, build the debug server, and launch the Extension Development Host
+4. Open a `.kql` file to activate the extension
 
 ## Debugging
 
 ### Debugging the Client
 
-1. Open the `src/Client` folder in VS Code
-2. Build the client using the `compile` task in the **NPM SCRIPTS** explorer panel
-3. Build the server using `build-debug-server` in the same panel
-4. Press **F5** to launch the Extension Development Host with debugging enabled
+1. Open the repository root folder in VS Code
+2. Select the **Run Extension** debug profile
+3. Press **F5** to build the client, build the debug server, and launch the Extension Development Host with debugging enabled
 
 ### Debugging the Server
 


### PR DESCRIPTION
## Summary
- Add a shared VS Code Run Extension launch profile
- Add pre-launch tasks to build the client and debug language server
- Update contributor debugging instructions to use the new profile

## Validation
- npm ci
- npm run compile
- npm run build-debug-server