### PR TITLE
Show query CodeLens only for active query

### DIFF
--- a/src/Client/features/queryEditor.ts
+++ b/src/Client/features/queryEditor.ts
@@ -21,6 +21,7 @@ import { isQueryRangeInScope } from './queryRangeScope';
 const PASTE_KIND = vscode.DocumentDropOrPasteEditKind.Text.append('kusto');
 const QUERY_RUNNING_CONTEXT_KEY = 'msKustoExplorer.queryRunning';
 const MIN_QUERY_RUNNING_INDICATOR_MS = 500;
+const CODE_LENS_REFRESH_DEBOUNCE_MS = 100;
 
 /**
  * Builds a SelectionRange from optional CodeLens arguments.
@@ -155,6 +156,17 @@ export class QueryEditor {
 
         // Register CodeLens provider for queries
         this.codeLensProvider = new KustoCodeLensProvider(this.server, this.history);
+        let codeLensRefreshTimer: NodeJS.Timeout | undefined;
+        const scheduleCodeLensRefresh = () => {
+            if (codeLensRefreshTimer) {
+                clearTimeout(codeLensRefreshTimer);
+            }
+
+            codeLensRefreshTimer = setTimeout(() => {
+                this.codeLensProvider.refresh();
+                codeLensRefreshTimer = undefined;
+            }, CODE_LENS_REFRESH_DEBOUNCE_MS);
+        };
         context.subscriptions.push(
             vscode.languages.registerCodeLensProvider(
                 { language: 'kusto' },
@@ -162,10 +174,19 @@ export class QueryEditor {
             )
         );
         context.subscriptions.push(
-            vscode.window.onDidChangeActiveTextEditor(() => this.codeLensProvider.refresh()),
+            vscode.window.onDidChangeActiveTextEditor(editor => {
+                if (editor?.document.languageId === 'kusto') {
+                    scheduleCodeLensRefresh();
+                }
+            }),
             vscode.window.onDidChangeTextEditorSelection(event => {
                 if (event.textEditor.document.languageId === 'kusto') {
-                    this.codeLensProvider.refresh();
+                    scheduleCodeLensRefresh();
+                }
+            }),
+            new vscode.Disposable(() => {
+                if (codeLensRefreshTimer) {
+                    clearTimeout(codeLensRefreshTimer);
                 }
             })
         );
@@ -661,23 +682,25 @@ class KustoCodeLensProvider implements vscode.CodeLensProvider {
         const lenses: vscode.CodeLens[] = [];
 
         for (const range of result.ranges) {
-            const vsRange = new vscode.Range(
-                range.start.line, range.start.character,
-                range.end.line, range.end.character
-            );
-
-            const queryText = document.getText(vsRange);
-
-            // Skip empty or whitespace-only query ranges
-            if (queryText.trim().length === 0) {
-                continue;
-            }
-
             const isInScope = isQueryRangeInScope(range, activeSelections);
             const isQueryRangeRunning = !isEntityDefinition
                 && this.runningQueryRangeKeys.has(getQueryRangeKey(document.uri.toString(), range));
             if (!isInScope && !isQueryRangeRunning) {
                 continue;
+            }
+
+            const vsRange = new vscode.Range(
+                range.start.line, range.start.character,
+                range.end.line, range.end.character
+            );
+            let queryText: string | undefined;
+
+            // Skip empty or whitespace-only query ranges
+            if (isInScope) {
+                queryText = document.getText(vsRange);
+                if (queryText.trim().length === 0) {
+                    continue;
+                }
             }
 
             if (isInScope) {
@@ -700,7 +723,7 @@ class KustoCodeLensProvider implements vscode.CodeLensProvider {
                 }));
             }
 
-            if (!isInScope) {
+            if (!isInScope || queryText === undefined) {
                 continue;
             }
 

--- a/src/Client/features/queryEditor.ts
+++ b/src/Client/features/queryEditor.ts
@@ -16,6 +16,7 @@ import type { HistoryPanel } from './historyPanel';
 import type { IClipboard } from './clipboard';
 import type { ClipboardItem } from './clipboard';
 import { ENTITY_DEFINITION_SCHEME } from './entityDefinitionProvider';
+import { isQueryRangeInScope } from './queryRangeScope';
 
 const PASTE_KIND = vscode.DocumentDropOrPasteEditKind.Text.append('kusto');
 const QUERY_RUNNING_CONTEXT_KEY = 'msKustoExplorer.queryRunning';
@@ -159,6 +160,14 @@ export class QueryEditor {
                 { language: 'kusto' },
                 this.codeLensProvider
             )
+        );
+        context.subscriptions.push(
+            vscode.window.onDidChangeActiveTextEditor(() => this.codeLensProvider.refresh()),
+            vscode.window.onDidChangeTextEditorSelection(event => {
+                if (event.textEditor.document.languageId === 'kusto') {
+                    this.codeLensProvider.refresh();
+                }
+            })
         );
 
         // Register paste provider for clipboard context
@@ -642,6 +651,7 @@ class KustoCodeLensProvider implements vscode.CodeLensProvider {
 
     async provideCodeLenses(document: vscode.TextDocument): Promise<vscode.CodeLens[]> {
         const isEntityDefinition = document.uri.scheme === ENTITY_DEFINITION_SCHEME;
+        const activeSelections = getActiveSelectionRanges(document);
 
         const result = await this.server.getQueryRanges(document.uri.toString());
         if (!result || !result.ranges.length) {
@@ -663,22 +673,35 @@ class KustoCodeLensProvider implements vscode.CodeLensProvider {
                 continue;
             }
 
-            lenses.push(new vscode.CodeLens(vsRange, {
-                title: '⬚ Select',
-                command: 'msKustoExplorer.selectQuery',
-                tooltip: 'Select this query',
-                arguments: [range.start.line, range.start.character, range.end.line, range.end.character]
-            }));
+            const isInScope = isQueryRangeInScope(range, activeSelections);
+            const isQueryRangeRunning = !isEntityDefinition
+                && this.runningQueryRangeKeys.has(getQueryRangeKey(document.uri.toString(), range));
+            if (!isInScope && !isQueryRangeRunning) {
+                continue;
+            }
 
-            // Hide Run, Format, and Results lenses in entity definition documents
-            if (!isEntityDefinition) {
-                const isQueryRangeRunning = this.runningQueryRangeKeys.has(getQueryRangeKey(document.uri.toString(), range));
+            if (isInScope) {
+                lenses.push(new vscode.CodeLens(vsRange, {
+                    title: '⬚ Select',
+                    command: 'msKustoExplorer.selectQuery',
+                    tooltip: 'Select this query',
+                    arguments: [range.start.line, range.start.character, range.end.line, range.end.character]
+                }));
+            }
+
+            // Hide Run, Format, and Results lenses in entity definition documents.
+            // Keep the running indicator visible even if focus moves to another query.
+            if (!isEntityDefinition && (isInScope || isQueryRangeRunning)) {
                 lenses.push(new vscode.CodeLens(vsRange, {
                     title: isQueryRangeRunning ? '$(sync~spin) Running' : '▶ Run',
                     command: isQueryRangeRunning ? 'msKustoExplorer.runQuery.running' : 'msKustoExplorer.runQuery',
                     tooltip: isQueryRangeRunning ? 'This Kusto query is running' : 'Run this query',
                     arguments: [range.start.line, range.start.character, range.end.line, range.end.character]
                 }));
+            }
+
+            if (!isInScope) {
+                continue;
             }
 
             lenses.push(new vscode.CodeLens(vsRange, {
@@ -729,6 +752,18 @@ class KustoCodeLensProvider implements vscode.CodeLensProvider {
 
         return lenses;
     }
+}
+
+function getActiveSelectionRanges(document: vscode.TextDocument): SelectionRange[] {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (!activeEditor || activeEditor.document.uri.toString() !== document.uri.toString()) {
+        return [];
+    }
+
+    return activeEditor.selections.map(selection => ({
+        start: { line: selection.start.line, character: selection.start.character },
+        end: { line: selection.end.line, character: selection.end.character }
+    }));
 }
 
 // =============================================================================
@@ -806,12 +841,12 @@ class KustoPasteEditProvider implements vscode.DocumentPasteEditProvider {
  */
 function activateQuerySeparators(context: vscode.ExtensionContext, server: IServer, errorRangeDecoration: vscode.TextEditorDecorationType): void {
 
-    // Decoration for separator line between queries
+    // Optional, subtle separator line between queries.
     const querySeparatorDecoration = vscode.window.createTextEditorDecorationType({
         isWholeLine: true,
-        borderWidth: '0 0 3px 0',
+        borderWidth: '0 0 1px 0',
         borderStyle: 'solid',
-        borderColor: 'rgba(128, 128, 128, 0.25)',
+        borderColor: 'rgba(128, 128, 128, 0.14)',
     });
 
     // Map to track debounce timers per document URI
@@ -834,7 +869,7 @@ function activateQuerySeparators(context: vscode.ExtensionContext, server: IServ
             );
 
             const config = vscode.workspace.getConfiguration('msKustoExplorer');
-            const enableSeparators = config.get<boolean>('editor.showQuerySeparators', true);
+            const enableSeparators = config.get<boolean>('editor.showQuerySeparators', false);
 
             const firstEditor = editors[0];
             if (!firstEditor) {

--- a/src/Client/features/queryRangeScope.ts
+++ b/src/Client/features/queryRangeScope.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import type { Position, Range, SelectionRange } from './server';
+
+function comparePositions(left: Position, right: Position): number {
+    if (left.line !== right.line) {
+        return left.line - right.line;
+    }
+
+    return left.character - right.character;
+}
+
+function isEmptyRange(range: SelectionRange): boolean {
+    return comparePositions(range.start, range.end) === 0;
+}
+
+function normalizeRange(range: SelectionRange): SelectionRange {
+    return comparePositions(range.start, range.end) <= 0
+        ? range
+        : { start: range.end, end: range.start };
+}
+
+function containsPosition(range: Range, position: Position): boolean {
+    return comparePositions(position, range.start) >= 0
+        && comparePositions(position, range.end) <= 0;
+}
+
+function intersectsRange(queryRange: Range, selectionRange: SelectionRange): boolean {
+    return comparePositions(selectionRange.start, queryRange.end) < 0
+        && comparePositions(selectionRange.end, queryRange.start) > 0;
+}
+
+export function isQueryRangeInScope(queryRange: Range, selections: readonly SelectionRange[]): boolean {
+    return selections.some(selection => {
+        const normalizedSelection = normalizeRange(selection);
+        return isEmptyRange(normalizedSelection)
+            ? containsPosition(queryRange, normalizedSelection.start)
+            : intersectsRange(queryRange, normalizedSelection);
+    });
+}

--- a/src/Client/package.json
+++ b/src/Client/package.json
@@ -1082,8 +1082,8 @@
         "properties": {
           "msKustoExplorer.editor.showQuerySeparators": {
             "type": "boolean",
-            "default": true,
-            "description": "Show query separator lines (---) in the editor."
+            "default": false,
+            "description": "Show subtle separator lines between query blocks in the editor."
           }
         }
       },

--- a/src/Client/tests/unit/queryRangeScope.test.ts
+++ b/src/Client/tests/unit/queryRangeScope.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { describe, expect, it } from 'vitest';
+import { isQueryRangeInScope } from '../../features/queryRangeScope';
+import type { Range, SelectionRange } from '../../features/server';
+
+function range(startLine: number, startCharacter: number, endLine: number, endCharacter: number): Range {
+    return {
+        start: { line: startLine, character: startCharacter },
+        end: { line: endLine, character: endCharacter }
+    };
+}
+
+function selection(startLine: number, startCharacter: number, endLine: number, endCharacter: number): SelectionRange {
+    return range(startLine, startCharacter, endLine, endCharacter);
+}
+
+describe('isQueryRangeInScope', () => {
+    const queryRange = range(2, 0, 4, 20);
+
+    it('returns true when the cursor is inside the query range', () => {
+        expect(isQueryRangeInScope(queryRange, [selection(3, 5, 3, 5)])).toBe(true);
+    });
+
+    it('returns true when the cursor is at the end of the query range', () => {
+        expect(isQueryRangeInScope(queryRange, [selection(4, 20, 4, 20)])).toBe(true);
+    });
+
+    it('returns true when a selection intersects the query range', () => {
+        expect(isQueryRangeInScope(queryRange, [selection(1, 0, 2, 5)])).toBe(true);
+    });
+
+    it('returns true when any selection intersects the query range', () => {
+        expect(isQueryRangeInScope(queryRange, [
+            selection(0, 0, 0, 0),
+            selection(3, 0, 3, 8)
+        ])).toBe(true);
+    });
+
+    it('normalizes reversed selections before checking scope', () => {
+        expect(isQueryRangeInScope(queryRange, [selection(3, 8, 3, 0)])).toBe(true);
+    });
+
+    it('returns false when there are no active selections', () => {
+        expect(isQueryRangeInScope(queryRange, [])).toBe(false);
+    });
+
+    it('returns false when the cursor is outside the query range', () => {
+        expect(isQueryRangeInScope(queryRange, [selection(5, 0, 5, 0)])).toBe(false);
+    });
+
+    it('returns false when a selection only touches the query start boundary', () => {
+        expect(isQueryRangeInScope(queryRange, [selection(1, 0, 2, 0)])).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Show query action CodeLens entries only for the active query block
- Keep the running indicator visible when focus moves away from a running query
- Disable query separators by default and make opt-in separators more subtle
- Add range-scope unit tests for cursor, selection, multi-selection, reversed selection, and boundary cases

## Validation
- npm run compile
- npm test
- npx eslint features\queryEditor.ts features\queryRangeScope.ts --max-warnings 0

## Notes
- npm run type-check currently fails in node_modules/fast-xml-parser/lib/fxp.d.cts with TS1435
- npm run lint currently fails in src/Client/features/authentication.ts with @typescript-eslint/no-floating-promises