### PR TITLE
Fix blank chart webview setup

### DIFF
--- a/src/Client/features/graphChartProvider.ts
+++ b/src/Client/features/graphChartProvider.ts
@@ -214,7 +214,7 @@ export class GraphChartProvider implements IChartProvider {
 
     createView(webview: IWebView): IChartView {
         webview.setup(
-            `<script src="${CytoscapeJsCdn}" charset="utf-8"></script>`,
+            `<script defer src="${CytoscapeJsCdn}" charset="utf-8"></script>`,
             ''
         );
         return new GraphChartView(webview, (data, options, darkMode, ctx, positions, token, seed) => this.renderGraphHtml(data, options, darkMode, ctx, positions, token, seed));

--- a/src/Client/features/resultsViewer.ts
+++ b/src/Client/features/resultsViewer.ts
@@ -37,6 +37,8 @@ export type ResultViewMode = 'chart' | 'data' | 'detail' | 'all';
 export class WebViewAdapter implements IWebView {
     private readonly webview: vscode.Webview;
     private readonly contentCommand: string;
+    private readonly headFragments = new Set<string>();
+    private readonly scriptFragments = new Set<string>();
     headHtml = '';
     scriptsHtml = '';
     contentHtml = '';
@@ -56,8 +58,16 @@ export class WebViewAdapter implements IWebView {
     }
 
     setup(headHtml: string, scriptsHtml: string): void {
-        this.headHtml += this.headHtml && headHtml ? `\n${headHtml}` : headHtml;
-        this.scriptsHtml += this.scriptsHtml && scriptsHtml ? `\n${scriptsHtml}` : scriptsHtml;
+        this.headHtml = this.appendSetupFragment(this.headHtml, this.headFragments, headHtml);
+        this.scriptsHtml = this.appendSetupFragment(this.scriptsHtml, this.scriptFragments, scriptsHtml);
+    }
+
+    private appendSetupFragment(current: string, fragments: Set<string>, fragment: string): string {
+        if (!fragment || fragments.has(fragment)) {
+            return current;
+        }
+        fragments.add(fragment);
+        return current ? `${current}\n${fragment}` : fragment;
     }
 
     setContent(html: string): void {

--- a/src/Client/features/resultsViewer.ts
+++ b/src/Client/features/resultsViewer.ts
@@ -56,8 +56,8 @@ export class WebViewAdapter implements IWebView {
     }
 
     setup(headHtml: string, scriptsHtml: string): void {
-        this.headHtml += headHtml;
-        this.scriptsHtml += scriptsHtml;
+        this.headHtml += this.headHtml && headHtml ? `\n${headHtml}` : headHtml;
+        this.scriptsHtml += this.scriptsHtml && scriptsHtml ? `\n${scriptsHtml}` : scriptsHtml;
     }
 
     setContent(html: string): void {

--- a/src/Client/features/resultsViewer.ts
+++ b/src/Client/features/resultsViewer.ts
@@ -34,7 +34,7 @@ export type ResultViewMode = 'chart' | 'data' | 'detail' | 'all';
  * Stores page-level setup content (headHtml, scriptsHtml) for the page builder to read.
  * `setContent()` posts the given `contentCommand` message to the page handler.
  */
-class WebViewAdapter implements IWebView {
+export class WebViewAdapter implements IWebView {
     private readonly webview: vscode.Webview;
     private readonly contentCommand: string;
     headHtml = '';
@@ -56,8 +56,8 @@ class WebViewAdapter implements IWebView {
     }
 
     setup(headHtml: string, scriptsHtml: string): void {
-        this.headHtml = headHtml;
-        this.scriptsHtml = scriptsHtml;
+        this.headHtml += headHtml;
+        this.scriptsHtml += scriptsHtml;
     }
 
     setContent(html: string): void {

--- a/src/Client/features/webview.ts
+++ b/src/Client/features/webview.ts
@@ -14,13 +14,15 @@
 /**
  * Abstraction for a region within a webview page.
  *
- * A controller calls `setup()` to declare page-level dependencies
- * (scripts, styles), then uses `setContent()` to push HTML into its
- * region of the page.  `invoke()` / `handle()` provide bidirectional
- * messaging between the extension and the webview page scripts.
+ * Controllers may call `setup()` multiple times to declare page-level
+ * dependencies (scripts, styles); implementations should accumulate
+ * those fragments rather than replacing earlier ones. Controllers then
+ * use `setContent()` to push HTML into their region of the page.
+ * `invoke()` / `handle()` provide bidirectional messaging between the
+ * extension and the webview page scripts.
  */
 export interface IWebView {
-    /** Setup: provide HTML for the page &lt;head&gt; and end-of-body scripts. */
+    /** Setup: add HTML for the page &lt;head&gt; and end-of-body scripts. */
     setup(headHtml: string, scriptsHtml: string): void;
     /** Push HTML content into the controller's region of the page. */
     setContent(html: string): void;

--- a/src/Client/features/webview.ts
+++ b/src/Client/features/webview.ts
@@ -14,13 +14,13 @@
 /**
  * Abstraction for a region within a webview page.
  *
- * A controller calls `setup()` once to declare page-level dependencies
+ * A controller calls `setup()` to declare page-level dependencies
  * (scripts, styles), then uses `setContent()` to push HTML into its
  * region of the page.  `invoke()` / `handle()` provide bidirectional
  * messaging between the extension and the webview page scripts.
  */
 export interface IWebView {
-    /** One-time setup: provide HTML for the page &lt;head&gt; and end-of-body scripts. */
+    /** Setup: provide HTML for the page &lt;head&gt; and end-of-body scripts. */
     setup(headHtml: string, scriptsHtml: string): void;
     /** Push HTML content into the controller's region of the page. */
     setContent(html: string): void;

--- a/src/Client/features/webview.ts
+++ b/src/Client/features/webview.ts
@@ -14,12 +14,13 @@
 /**
  * Abstraction for a region within a webview page.
  *
- * Controllers may call `setup()` multiple times to declare page-level
- * dependencies (scripts, styles); implementations should accumulate
- * those fragments rather than replacing earlier ones. Controllers then
- * use `setContent()` to push HTML into their region of the page.
- * `invoke()` / `handle()` provide bidirectional messaging between the
- * extension and the webview page scripts.
+ * Controllers may call `setup()` multiple times during region construction to
+ * declare page-level dependencies (scripts, styles); implementations should
+ * accumulate those fragments rather than replacing earlier ones. Re-registering
+ * the same fragment should be idempotent so repeated construction attempts do
+ * not duplicate page scripts. Controllers then use `setContent()` to push HTML
+ * into their region of the page. `invoke()` / `handle()` provide bidirectional
+ * messaging between the extension and the webview page scripts.
  */
 export interface IWebView {
     /** Setup: add HTML for the page &lt;head&gt; and end-of-body scripts. */

--- a/src/Client/tests/unit/graphChartProvider.test.ts
+++ b/src/Client/tests/unit/graphChartProvider.test.ts
@@ -92,6 +92,7 @@ describe('GraphChartProvider', () => {
             expect(m.webview.setup).toHaveBeenCalledTimes(1);
             const head = m.webview.setup.mock.calls[0]?.[0] as string;
             expect(head).toContain('cytoscape');
+            expect(head).toContain('defer');
         });
     });
 

--- a/src/Client/tests/unit/resultsViewer.test.ts
+++ b/src/Client/tests/unit/resultsViewer.test.ts
@@ -36,4 +36,14 @@ describe('WebViewAdapter', () => {
         expect(adapter.headHtml).toBe('<meta name="first">\n<meta name="second">');
         expect(adapter.scriptsHtml).toBe('<script>first();</script>\n<script>second();</script>');
     });
+
+    it('does not duplicate identical setup fragments', () => {
+        const adapter = new WebViewAdapter(createMockVsCodeWebview());
+
+        adapter.setup('<meta name="same">', '<script>same();</script>');
+        adapter.setup('<meta name="same">', '<script>same();</script>');
+
+        expect(adapter.headHtml).toBe('<meta name="same">');
+        expect(adapter.scriptsHtml).toBe('<script>same();</script>');
+    });
 });

--- a/src/Client/tests/unit/resultsViewer.test.ts
+++ b/src/Client/tests/unit/resultsViewer.test.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
+import { CompositeChartProvider } from '../../features/compositeChartProvider';
+import { WebViewAdapter } from '../../features/resultsViewer';
+
+function createMockVsCodeWebview(): vscode.Webview {
+    return {
+        postMessage: vi.fn(),
+        onDidReceiveMessage: vi.fn(() => ({ dispose: () => { } })),
+    } as unknown as vscode.Webview;
+}
+
+describe('WebViewAdapter', () => {
+    it('keeps setup dependencies from all chart providers sharing the same region', () => {
+        const adapter = new WebViewAdapter(createMockVsCodeWebview());
+
+        const view = new CompositeChartProvider().createView(adapter);
+
+        expect(adapter.headHtml).toContain('plotly');
+        expect(adapter.headHtml).toContain('cytoscape');
+        expect(adapter.scriptsHtml).toContain('setChartContent');
+        expect(adapter.scriptsHtml).toContain('chartViewReady');
+
+        view.dispose();
+    });
+});

--- a/src/Client/tests/unit/resultsViewer.test.ts
+++ b/src/Client/tests/unit/resultsViewer.test.ts
@@ -26,4 +26,14 @@ describe('WebViewAdapter', () => {
 
         view.dispose();
     });
+
+    it('separates accumulated setup fragments with newlines', () => {
+        const adapter = new WebViewAdapter(createMockVsCodeWebview());
+
+        adapter.setup('<meta name="first">', '<script>first();</script>');
+        adapter.setup('<meta name="second">', '<script>second();</script>');
+
+        expect(adapter.headHtml).toBe('<meta name="first">\n<meta name="second">');
+        expect(adapter.scriptsHtml).toBe('<script>first();</script>\n<script>second();</script>');
+    });
 });


### PR DESCRIPTION
Fixes #129

## Summary
- Accumulate chart webview setup fragments instead of replacing earlier provider dependencies.
- Preserve Plotly scripts and message handlers when the composite chart provider also initializes Graph/Cytoscape support.
- Add regression coverage for shared chart-region setup.

## Validation
- `npm test` (500 passed)
- `npm run compile`
- `npx vitest run tests/unit/resultsViewer.test.ts`
- `npx vitest run tests/unit/plotlyChartProvider.test.ts`
- `dotnet build src/Server/Server.csproj`
- `dotnet run --project src/ServerTests/ServerTests.csproj` (200 passed)
- `npm run test:integration` (46 passed)
- Packaged and installed `src/Client/kusto-explorer-vscode-0.2.0.vsix`; manual chart smoke test passed

## Notes
- `npm run type-check` is currently blocked locally by a dependency declaration typo in `node_modules/fast-xml-parser/lib/fxp.d.cts` (`devlare class XMLBuilder`).
- `npm run lint` is currently blocked locally by an unrelated existing floating-promise error in `src/Client/features/authentication.ts`.