### PR TITLE
Bump extension version to 1.0.1

### DIFF
--- a/src/Client/package-lock.json
+++ b/src/Client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kusto-explorer-vscode",
-  "version": "0.2.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kusto-explorer-vscode",
-      "version": "0.2.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^5.7.0",

--- a/src/Client/package.json
+++ b/src/Client/package.json
@@ -2,7 +2,7 @@
   "name": "kusto-explorer-vscode",
   "displayName": "Microsoft Kusto Explorer",
   "description": "Edit, run and chart Kusto queries (KQL).",
-  "version": "0.2.0",
+  "version": "1.0.1",
   "publisher": "ms-kusto",
   "author": "Microsoft",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump the VS Code extension package metadata from `0.2.0` to `1.0.1`.
- Keep `package.json` and `package-lock.json` aligned with the next hotfix release after `v1.0.0`.

## Why
The Marketplace and GitHub latest release are already `1.0.0`, but the checked-in client package metadata still said `0.2.0`. That made local packaging and direct `vsce publish` flows produce or target the wrong version.

## Validation
- `node` metadata check confirmed `package.json`, root lockfile version, and lockfile package version are all `1.0.1`.
- `npm run package` produced `src/Client/kusto-explorer-vscode-1.0.1.vsix`.