### PR TITLE
Clean up unused code and release packaging

### DIFF
--- a/src/Client/.vscodeignore
+++ b/src/Client/.vscodeignore
@@ -15,6 +15,10 @@ node_modules/**
 server/**/*.pdb
 
 # Development files
+tests/**
+.vscode-test.mjs
+tsconfig.integration.json
+**/*.kqr
 .gitignore
 .git/**
 **/*.bat

--- a/src/Client/features/connectionManager.ts
+++ b/src/Client/features/connectionManager.ts
@@ -14,8 +14,8 @@ import type { IServer, DatabaseInfo } from './server';
 // Storage Keys
 // =============================================================================
 
-export const SERVERS_STORAGE_KEY = 'kusto.serversAndGroups';
-export const DOCUMENT_CONNECTIONS_KEY = 'kusto.documentConnections';
+const SERVERS_STORAGE_KEY = 'kusto.serversAndGroups';
+const DOCUMENT_CONNECTIONS_KEY = 'kusto.documentConnections';
 
 // =============================================================================
 // Data Types

--- a/src/Client/features/connectionsPanel.ts
+++ b/src/Client/features/connectionsPanel.ts
@@ -1583,7 +1583,7 @@ class KustoDragAndDropController implements vscode.TreeDragAndDropController<Kus
 
     constructor(private readonly connections: ConnectionManager, private readonly onDragStart: () => void) {}
 
-    async handleDrag(source: readonly KustoTreeItem[], dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken): Promise<void> {
+    async handleDrag(source: readonly KustoTreeItem[], dataTransfer: vscode.DataTransfer, _token: vscode.CancellationToken): Promise<void> {
         // Suppress selection changes during drag
         this.onDragStart();
 
@@ -1619,7 +1619,7 @@ class KustoDragAndDropController implements vscode.TreeDragAndDropController<Kus
         }
     }
 
-    async handleDrop(target: KustoTreeItem | undefined, dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken): Promise<void> {
+    async handleDrop(target: KustoTreeItem | undefined, dataTransfer: vscode.DataTransfer, _token: vscode.CancellationToken): Promise<void> {
         const transferItem = dataTransfer.get('application/vnd.code.tree.mskustoexplorer_connections');
         if (!transferItem) {
             return;
@@ -1661,7 +1661,7 @@ class KustoDocumentDropEditProvider implements vscode.DocumentDropEditProvider {
 
     async provideDocumentDropEdits(
         document: vscode.TextDocument,
-        position: vscode.Position,
+        _position: vscode.Position,
         dataTransfer: vscode.DataTransfer,
         token: vscode.CancellationToken
     ): Promise<vscode.DocumentDropEdit | undefined> {

--- a/src/Client/features/copilot.ts
+++ b/src/Client/features/copilot.ts
@@ -441,7 +441,7 @@ async function runQuery(input: { query: string; cluster?: string; database?: str
  */
 async function handleChatRequest(
     request: vscode.ChatRequest,
-    context: vscode.ChatContext,
+    _context: vscode.ChatContext,
     stream: vscode.ChatResponseStream,
     token: vscode.CancellationToken
 ): Promise<vscode.ChatResult> {

--- a/src/Client/features/plotlyChartProvider.ts
+++ b/src/Client/features/plotlyChartProvider.ts
@@ -2907,7 +2907,7 @@ export class PlotlyChartProvider implements IChartProvider {
             }
             builder = builder.addSecondaryYAxis('yaxis2', {
                 overlaying: 'y',
-                side: 'right',
+                side: PlotlyAxisSides.Right,
                 showgrid: false,
             });
         } else if (options.yLayout === ChartYLayout.SeparatePanels && yColumns.length > 1) {

--- a/src/Client/features/queryEditor.ts
+++ b/src/Client/features/queryEditor.ts
@@ -13,8 +13,7 @@ import { ResultsViewer } from './resultsViewer';
 import { HistoryManager } from './historyManager';
 import type { HistoryEntry } from './historyManager';
 import type { HistoryPanel } from './historyPanel';
-import type { IClipboard } from './clipboard';
-import type { ClipboardItem } from './clipboard';
+import { formatCfHtml, type ClipboardItem, type IClipboard } from './clipboard';
 import { ENTITY_DEFINITION_SCHEME } from './entityDefinitionProvider';
 
 const PASTE_KIND = vscode.DocumentDropOrPasteEditKind.Text.append('kusto');
@@ -515,7 +514,7 @@ export class QueryEditor {
 
                 // Place both HTML and plain text on the clipboard
                 const items: ClipboardItem[] = [
-                    { format: 'HTML Format', data: wrapHtmlForClipboard(result.html) },
+                    { format: 'HTML Format', data: formatCfHtml(result.html) },
                     { format: 'Text', data: plainText, encoding: 'text' }
                 ];
 
@@ -752,8 +751,8 @@ class KustoPasteEditProvider implements vscode.DocumentPasteEditProvider {
         document: vscode.TextDocument,
         ranges: readonly vscode.Range[],
         dataTransfer: vscode.DataTransfer,
-        context: vscode.DocumentPasteEditContext,
-        token: vscode.CancellationToken
+        _context: vscode.DocumentPasteEditContext,
+        _token: vscode.CancellationToken
     ): Promise<vscode.DocumentPasteEdit[] | undefined> {
         const clipboardContext = this.clipboard.getContext();
         if (!clipboardContext) {
@@ -975,39 +974,6 @@ function requestSemanticTokens(document: vscode.TextDocument): void {
     ).catch(() => undefined);
 }
 
-/**
- * Wraps HTML content in the CF_HTML clipboard format header required by Windows.
- */
-function wrapHtmlForClipboard(html: string): string {
-    // CF_HTML format requires specific headers with byte offsets
-    const header = 'Version:0.9\r\nStartHTML:SSSSSSSSSS\r\nEndHTML:EEEEEEEEEE\r\nStartFragment:FFFFFFFFFF\r\nEndFragment:GGGGGGGGGG\r\n';
-    const startFragment = '<!--StartFragment-->';
-    const endFragment = '<!--EndFragment-->';
-    const body = `<!DOCTYPE html><html><body>${startFragment}${html}${endFragment}</body></html>`;
-    const full = header + body;
-
-    // Calculate byte offsets (CF_HTML uses byte positions)
-    const encoder = new TextEncoder();
-    const headerBytes = encoder.encode(header).length;
-    const startFragOffset = headerBytes + encoder.encode(`<!DOCTYPE html><html><body>${startFragment}`).length - encoder.encode(startFragment).length + encoder.encode(startFragment).length;
-    const fullBytes = encoder.encode(full).length;
-
-    // Simpler: compute offsets by measuring
-    const beforeFragment = header + `<!DOCTYPE html><html><body>`;
-    const afterStartFragment = beforeFragment + startFragment;
-    const beforeEndFragment = afterStartFragment + html;
-    
-    const startHtml = encoder.encode(header).length;
-    const endHtml = encoder.encode(full).length;
-    const startFrag = encoder.encode(afterStartFragment).length;
-    const endFrag = encoder.encode(beforeEndFragment).length;
-
-    return full
-        .replace('SSSSSSSSSS', startHtml.toString().padStart(10, '0'))
-        .replace('EEEEEEEEEE', endHtml.toString().padStart(10, '0'))
-        .replace('FFFFFFFFFF', startFrag.toString().padStart(10, '0'))
-        .replace('GGGGGGGGGG', endFrag.toString().padStart(10, '0'));
-}
 
 /**
  * Forces VS Code to invalidate semantic token cache by making a real edit on all visible Kusto editors.

--- a/src/Client/features/resultsViewer.ts
+++ b/src/Client/features/resultsViewer.ts
@@ -97,7 +97,7 @@ interface ResultViewerState {
 /**
  * Determines if VS Code is currently using a dark color theme.
  */
-export function isDarkMode(): boolean {
+function isDarkMode(): boolean {
     const colorTheme = vscode.window.activeColorTheme;
     return colorTheme.kind === vscode.ColorThemeKind.Dark ||
            colorTheme.kind === vscode.ColorThemeKind.HighContrast;
@@ -432,7 +432,6 @@ export class ResultsViewer {
     // ─── Bottom view state ──────────────────────────────────────────────
     private resultsPanel: vscode.WebviewView | undefined;
     private lastPanelResultData: server.ResultData | undefined;
-    private lastPanelTableNames: string[] = [];
     private panelActiveTabIndex = 0;
     private panelActiveView: string = 'table-0';
     private panelHasChart = false;
@@ -489,7 +488,7 @@ export class ResultsViewer {
         this.chartProvider = chartProvider;
         this.chartEditorProvider = chartEditorProvider;
         this.dataTableProvider = dataTableProvider;
-        this.htmlBuilder = new DocumentViewProvider(this.createPanelStateAccessor(), server, chartProvider, chartEditorProvider, dataTableProvider);
+        this.htmlBuilder = new DocumentViewProvider(this.createPanelStateAccessor(), chartProvider, chartEditorProvider, dataTableProvider);
 
         context.subscriptions.push(
             vscode.window.registerCustomEditorProvider(
@@ -671,7 +670,6 @@ export class ResultsViewer {
         vscode.commands.executeCommand('setContext', 'msKustoExplorer.panelHasChart', hasChart);
         vscode.commands.executeCommand('setContext', 'msKustoExplorer.panelChartActive', hasChart);
         const hasTable = !!resultData.tables.length;
-        this.lastPanelTableNames = resultData.tables.map(t => t.name);
 
         if (!hasTable && !hasChart) {
             await this.showPanelHtml('<html><body>no results</body></html>');
@@ -726,7 +724,7 @@ export class ResultsViewer {
             this.panelEditorView?.setOptions(rawChartOptions, columnNames, chartDefaults, resultData.tables.map(t => ({ name: t.name, columns: t.columns.map(c => c.name) })), chartTable?.name);
         }
 
-        const html = this.htmlBuilder.BuildMultiTabbedHtml(hasChart, mode, this.panelWebView, this.panelEditorWebView, chartOptions, columnNames,
+        const html = this.htmlBuilder.BuildMultiTabbedHtml(hasChart, mode, this.panelWebView, this.panelEditorWebView, chartOptions,
             resultData.query, resultData.cluster, resultData.database, resultData.tables, this.panelTableWebViews);
 
         const totalRows = resultData.tables.reduce((sum, t) => sum + t.rows.length, 0);
@@ -880,7 +878,7 @@ export class ResultsViewer {
             if (editorAdapter) { editorAdapter.suppressMessages = priorEditorSuppress; }
         }
 
-        const html = this.htmlBuilder.BuildMultiTabbedHtml(hasChart, mode, this.singletonWebView, this.singletonEditorWebView, chartOptions, columnNames,
+        const html = this.htmlBuilder.BuildMultiTabbedHtml(hasChart, mode, this.singletonWebView, this.singletonEditorWebView, chartOptions,
             resultData.query, resultData.cluster, resultData.database, resultData.tables, this.singletonTableWebViews);
 
         this.showSingletonView(injectMessageHandlerScripts(html), resultData, resultData.tables.map(t => t.name), singletonLocation, mode);
@@ -1011,7 +1009,6 @@ export class ResultsViewer {
             this.resultsPanel.badge = undefined;
         }
         this.lastPanelResultData = undefined;
-        this.lastPanelTableNames = [];
         this.panelHasChart = false;
         this.panelActiveView = 'table-0';
         vscode.commands.executeCommand('setContext', 'msKustoExplorer.panelHasChart', false);
@@ -1231,8 +1228,7 @@ export class ResultsViewer {
             } else {
                 // Re-render without the chart
                 const tableNames = updated.tables.map(t => t.name);
-                const columnNames = updated.tables[0]?.columns?.map(c => c.name) ?? [];
-                const html = this.htmlBuilder.BuildMultiTabbedHtml(false, this.singletonMode ?? 'all', this.singletonWebView, this.singletonEditorWebView, undefined, columnNames,
+                const html = this.htmlBuilder.BuildMultiTabbedHtml(false, this.singletonMode ?? 'all', this.singletonWebView, this.singletonEditorWebView, undefined,
                     updated.query, updated.cluster, updated.database, updated.tables, this.singletonTableWebViews);
                 this.singletonView!.webview.html = injectMessageHandlerScripts(html);
 
@@ -1312,14 +1308,6 @@ export class ResultsViewer {
         return this.dataTableViews.get(panel);
     }
 
-    private getActiveTableName(state: ResultViewerState): string | undefined {
-        const match = state.activeView.match(/^table-(\d+)$/);
-        if (match) {
-            const idx = parseInt(match[1]!, 10);
-            return state.tableNames[idx];
-        }
-        return state.tableNames[0];
-    }
 
     /**
      * Default \"Copy\" / Ctrl+C: TSV plain text + CF_HTML rich text.
@@ -1616,7 +1604,7 @@ class DocumentViewProvider implements vscode.CustomTextEditorProvider {
         return next;
     }
 
-    constructor(private readonly viewer: IViewerPanelState, private readonly server: IServer, private readonly chartProvider: IChartProvider, private readonly chartEditorProvider: IChartEditorProvider, private readonly dataTableProvider: IDataTableProvider) {
+    constructor(private readonly viewer: IViewerPanelState, private readonly chartProvider: IChartProvider, private readonly chartEditorProvider: IChartEditorProvider, private readonly dataTableProvider: IDataTableProvider) {
     }
 
     async resolveCustomTextEditor(
@@ -1871,7 +1859,7 @@ class DocumentViewProvider implements vscode.CustomTextEditorProvider {
             editorView?.setOptions(rawChartOptions, columnNames, chartDefaults, resultData.tables.map(t => ({ name: t.name, columns: t.columns.map(c => c.name) })), chartTable?.name);
         }
 
-        const html = this.BuildMultiTabbedHtml(hasChart, 'all', docWebView, docEditorWebView, chartOptions, columnNames,
+        const html = this.BuildMultiTabbedHtml(hasChart, 'all', docWebView, docEditorWebView, chartOptions,
             resultData.query, resultData.cluster, resultData.database, resultData.tables, docTableWebViews);
         webviewPanel.webview.html = injectMessageHandlerScripts(html);
     }
@@ -1899,7 +1887,6 @@ class DocumentViewProvider implements vscode.CustomTextEditorProvider {
         webview: WebViewAdapter | undefined,
         editorWebView: WebViewAdapter | undefined,
         chartOptions?: server.ChartOptions,
-        columnNames?: string[],
         queryText?: string,
         cluster?: string,
         database?: string,

--- a/src/Client/features/server.ts
+++ b/src/Client/features/server.ts
@@ -6,7 +6,6 @@ import { CancellationToken, Disposable, ExtensionContext } from 'vscode';
 import {
     acquireMicrosoftAuthenticationToken,
     GetAuthenticationTokenParams,
-    GetAuthenticationTokenResult,
 } from './authentication';
 
 /**
@@ -743,12 +742,12 @@ export interface DocumentReadyNotification {
 }
 
 /** Parameters for the server's getData request. */
-export interface GetDataParams {
+interface GetDataParams {
     key: string;
 }
 
 /** Parameters for the server's setData request. */
-export interface SetDataParams {
+interface SetDataParams {
     key: string;
     data: object | undefined;
 }

--- a/src/Client/package-lock.json
+++ b/src/Client/package-lock.json
@@ -16,8 +16,6 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^18.0.0",
         "@types/vscode": "^1.90.0",
-        "@typescript-eslint/eslint-plugin": "^8.62.0",
-        "@typescript-eslint/parser": "^8.62.0",
         "@vscode/test-cli": "^0.0.15",
         "@vscode/test-electron": "^2.5.2",
         "esbuild": "^0.28.1",

--- a/src/Client/package.json
+++ b/src/Client/package.json
@@ -41,7 +41,7 @@
     "build-release-server": "dotnet publish ../Server/Server.csproj -c Release -o ./server",
     "build-debug-server": "dotnet publish ../Server/Server.csproj -c Debug -o ./server",
     "prepackage": "node -e \"require('fs').copyFileSync('../../LICENSE','./LICENSE')\" && npm run compile && npm run build-release-server",
-    "package": "npm run prepackage && vsce package",
+    "package": "vsce package",
     "package:version": "npm run prepackage && vsce package --no-update-package-json $VERSION",
     "publish": "vsce publish"
   },
@@ -1098,43 +1098,81 @@
           },
           "msKustoExplorer.format.generalSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "one",
             "description": "Whitespace between adjacent tokens when no other spacing rule applies"
           },
           "msKustoExplorer.format.prefixOperatorSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace between a prefix unary operator and its operand: -a, - a"
           },
           "msKustoExplorer.format.infixOperatorSpacing": {
             "type": "string",
-            "enum": ["asIs", "neither", "before", "after", "both"],
+            "enum": [
+              "asIs",
+              "neither",
+              "before",
+              "after",
+              "both"
+            ],
             "default": "both",
             "description": "Whitespace before and after a binary operator and its operands: a+b, a +b, a+ b, or a + b"
           },
           "msKustoExplorer.format.assignmentSpacing": {
             "type": "string",
-            "enum": ["asIs", "neither", "before", "after", "both"],
+            "enum": [
+              "asIs",
+              "neither",
+              "before",
+              "after",
+              "both"
+            ],
             "default": "both",
             "description": "Whitespace before and after assignment operators (=):  a=b, a= b, a =b, a = b"
           },
           "msKustoExplorer.format.rangeOperatorSpacing": {
             "type": "string",
-            "enum": ["asIs", "neither", "before", "after", "both"],
+            "enum": [
+              "asIs",
+              "neither",
+              "before",
+              "after",
+              "both"
+            ],
             "default": "both",
             "description": "Whitespace before and/or after the range operator (..): a..b, a ..b, a.. b, or a .. b"
           },
           "msKustoExplorer.format.commaSpacing": {
             "type": "string",
-            "enum": ["asIs", "neither", "before", "after", "both"],
+            "enum": [
+              "asIs",
+              "neither",
+              "before",
+              "after",
+              "both"
+            ],
             "default": "after",
             "description": "Whitespace before and/or after commas: a,b | a, b | a ,b | a , b"
           },
           "msKustoExplorer.format.colonSpacing": {
             "type": "string",
-            "enum": ["asIs", "neither", "before", "after", "both"],
+            "enum": [
+              "asIs",
+              "neither",
+              "before",
+              "after",
+              "both"
+            ],
             "default": "after",
             "description": "Whitespace before and/or after colons: a:b, a: b, a :b, a : b"
           },
@@ -1157,7 +1195,13 @@
           },
           "msKustoExplorer.format.pipeOperatorSpacing": {
             "type": "string",
-            "enum": ["asIs", "neither", "before", "after", "both"],
+            "enum": [
+              "asIs",
+              "neither",
+              "before",
+              "after",
+              "both"
+            ],
             "default": "both",
             "description": "Whitespace before and/or after the pipe operator (|): a|b, a |b, a| b, or a | b"
           },
@@ -1180,7 +1224,13 @@
           },
           "msKustoExplorer.format.semicolonSpacing": {
             "type": "string",
-            "enum": ["asIs", "neither", "before", "after", "both"],
+            "enum": [
+              "asIs",
+              "neither",
+              "before",
+              "after",
+              "both"
+            ],
             "default": "after",
             "description": "Whitespace before and/or after semicolons: a;b, a; b, a ;b, a ; b"
           },
@@ -1250,19 +1300,31 @@
           },
           "msKustoExplorer.format.beforeDataTableValueSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "one",
             "description": "Whitespace before a data table value's opening bracket"
           },
           "msKustoExplorer.format.dataTableValueSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace inside a non-empty data table value's brackets"
           },
           "msKustoExplorer.format.emptyDataTableValueSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace between brackets of an empty data table value"
           },
@@ -1278,19 +1340,31 @@
           },
           "msKustoExplorer.format.beforeFunctionBodySpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "one",
             "description": "Whitespace before a function body's opening brace"
           },
           "msKustoExplorer.format.functionBodySpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "one",
             "description": "Whitespace inside a non-empty function body's braces"
           },
           "msKustoExplorer.format.emptyFunctionBodySpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "one",
             "description": "Whitespace between braces of an empty function body"
           },
@@ -1306,19 +1380,31 @@
           },
           "msKustoExplorer.format.beforeParameterListSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace before a parameter list's opening parenthesis"
           },
           "msKustoExplorer.format.parameterListSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace inside a non-empty parameter list's parentheses"
           },
           "msKustoExplorer.format.emptyParameterListSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace between parentheses of an empty parameter list"
           },
@@ -1334,49 +1420,81 @@
           },
           "msKustoExplorer.format.beforeArgumentListSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace before an argument list's opening parenthesis"
           },
           "msKustoExplorer.format.argumentListSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace inside a non-empty argument list's parentheses"
           },
           "msKustoExplorer.format.emptyArgumentListSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace between parentheses of an empty argument list"
           },
           "msKustoExplorer.format.parenthesizedExpressionSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace inside a parenthesized expression's parentheses"
           },
           "msKustoExplorer.format.jsonArraySpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace inside a non-empty dynamic array's brackets: dynamic([1]) or dynamic([ 1 ])"
           },
           "msKustoExplorer.format.emptyJsonArraySpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace between brackets of an empty dynamic array: dynamic([]) or dynamic([ ])"
           },
           "msKustoExplorer.format.jsonObjectSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace inside a non-empty dynamic object's braces: dynamic({\"key\": \"value\"}) or dynamic({ \"key\": \"value\" })"
           },
           "msKustoExplorer.format.emptyJsonObjectSpacing": {
             "type": "string",
-            "enum": ["asIs", "minimal", "one"],
+            "enum": [
+              "asIs",
+              "minimal",
+              "one"
+            ],
             "default": "minimal",
             "description": "Whitespace between braces of an empty dynamic object: dynamic({}) or dynamic({ })"
           }
@@ -2226,8 +2344,6 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^18.0.0",
     "@types/vscode": "^1.90.0",
-    "@typescript-eslint/eslint-plugin": "^8.62.0",
-    "@typescript-eslint/parser": "^8.62.0",
     "@vscode/test-cli": "^0.0.15",
     "@vscode/test-electron": "^2.5.2",
     "esbuild": "^0.28.1",

--- a/src/Client/tsconfig.integration.json
+++ b/src/Client/tsconfig.integration.json
@@ -8,6 +8,8 @@
     "types": [ "node", "mocha" ],
     "sourceMap": true,
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "isolatedModules": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/src/Client/tsconfig.json
+++ b/src/Client/tsconfig.json
@@ -17,6 +17,8 @@
     // Stricter Typechecking Options
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
 
     // Recommended Options
     "strict": true,


### PR DESCRIPTION
## Summary
- reuse the shared, tested CF_HTML formatter for copied queries and remove the duplicate implementation flagged after #133 merged
- enable TypeScript unused-local and unused-parameter checks, then remove the dead state, helpers, parameters, imports, and redundant exports they exposed
- remove redundant direct TypeScript ESLint dependencies while retaining the umbrella package used by the ESLint configuration
- exclude integration-test inputs, saved query results, and generated VSIX files from release packages
- avoid running the `prepackage` build twice when invoking `npm run package`

## Validation
- `npm ci`
- `npm audit`
- `npm run type-check`
- `npm run lint`
- `npm test` — 502 passed
- `npm run build-release-server`
- `npm run test:integration` — 46 passed
- `dotnet build src/Server/Server.csproj -c Release -warnaserror`
- `dotnet run --project src/ServerTests/ServerTests.csproj -c Release` — 200 passed
- `npm run package` — packaged version 1.0.1 as a 114-file VSIX; verified tests, test configuration, `.kqr`, and nested `.vsix` files are absent

## Notes
- The package version was already bumped to 1.0.1; this PR does not change it.
- The remaining Knip-reported integration files are glob/configuration entry points, and its remaining exported-type reports are types used by exported interface shapes rather than dead code.